### PR TITLE
Optional configurable server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mail_room #
+# developmental work for non gmail servers for mail_room #
 
 mail_room is a configuration based process that will idle on IMAP connections and POST to a delivery URL whenever a new message is received on the configured mailbox and folder.
 

--- a/lib/mail_room/delivery/postback.rb
+++ b/lib/mail_room/delivery/postback.rb
@@ -19,9 +19,9 @@ module MailRoom
 
         connection.post do |request|
           request.url @mailbox.delivery_url
-          request.body = message
+          request.body = message.force_encoding('UTF-8')
           # request.options[:timeout] = 3
-          # request.headers['Content-Type'] = 'text/plain'
+          request.headers['Content-Type'] = 'text/plain'
         end
       end
     end

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -1,6 +1,7 @@
 module MailRoom
   # Mailbox Configuration fields
   FIELDS = [
+    :server,
     :email,
     :password,
     :name,

--- a/lib/mail_room/mailbox_handler.rb
+++ b/lib/mail_room/mailbox_handler.rb
@@ -36,7 +36,7 @@ module MailRoom
     # search for all new (unseen) message ids
     # @return [Array<Integer>] message ids
     def new_message_ids
-      @imap.search('UNSEEN')
+      @imap.search('NEW')
     end
 
     # @private

--- a/lib/mail_room/mailbox_watcher.rb
+++ b/lib/mail_room/mailbox_watcher.rb
@@ -18,7 +18,7 @@ module MailRoom
 
     # build a net/imap connection to google imap
     def imap
-      @imap ||= Net::IMAP.new('imap.gmail.com', :port => 993, :ssl => true)
+      @imap ||= Net::IMAP.new(( @mailbox && @mailbox.server) || 'imap.gmail.com', :port => 993, :ssl => true)
     end
 
     # build a handler to process mailbox messages

--- a/lib/mail_room/version.rb
+++ b/lib/mail_room/version.rb
@@ -1,4 +1,4 @@
 module MailRoom
   # Current version of MailRoom gem
-  VERSION = "0.2.1"
+  VERSION = "0.3.01"
 end

--- a/lib/mail_room/version.rb
+++ b/lib/mail_room/version.rb
@@ -1,4 +1,4 @@
 module MailRoom
   # Current version of MailRoom gem
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/lib/mailbox_watcher_spec.rb
+++ b/spec/lib/mailbox_watcher_spec.rb
@@ -30,6 +30,14 @@ describe MailRoom::MailboxWatcher do
 
       Net::IMAP.should have_received(:new).with('imap.gmail.com', :port => 993, :ssl => true)
     end
+    
+    it 'builds a new Net::IMAP object with server param' do
+      Net::IMAP.stubs(:new).returns('imap')
+      mailbox = stub(:server => 'outlook.office365.com', :email => 'drrosen@rosen.edu', :password => 'password', :name => 'inbox')
+      MailRoom::MailboxWatcher.new(mailbox).imap.should eq('imap')
+
+       Net::IMAP.should have_received(:new).with('outlook.office365.com', :port => 993, :ssl => true)
+    end
   end
 
   describe '#setup' do


### PR DESCRIPTION
allows setting :server: in config.yml
Spec testing server name used if present