### PR TITLE
Configurable imap search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ I would recommend having the `mail` gem bundled and parse the email using
 
 This setting allows configuration of the IMAP search command sent to the server. This still defaults 'UNSEEN'. You may find that 'NEW' works better for you.
 
+## IMAP Server Configuration ##
+
+You can set per-mailbox configuration for the IMAP server's `host` (default: 'imap.gmail.com'), `port` (default: 993), and `port` (default: true).
+
 ## Running in Production ##
 
 I suggest running with either upstart or init.d. Check out this wiki page for some example scripts for both: https://github.com/tpitale/mail_room/wiki/Init-Scripts-for-Running-mail_room

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
     :name: "inbox"
     :delivery_url: "http://localhost:3000/inbox"
     :delivery_token: "abcdefg"
+    :search_command: 'NEW'
   -
     :email: "user2@gmail.com"
     :password: "password"
@@ -100,6 +101,10 @@ disabled, you can get the raw string of the email using `request.body.read`.
 
 I would recommend having the `mail` gem bundled and parse the email using
 `Mail.read_from_string(request.body.read)`.
+
+## Search Command ##
+
+This setting allows configuration of the IMAP search command sent to the server. This still defaults 'UNSEEN'. You may find that 'NEW' works better for you.
 
 ## Running in Production ##
 

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -1,8 +1,12 @@
 module MailRoom
   # Mailbox Configuration fields
-  FIELDS = [
+  MAILBOX_FIELDS = [
     :email,
     :password,
+    :host,
+    :port,
+    :ssl,
+    :search_command,
     :name,
     :delivery_method, # :noop, :logger, :postback, :letter_opener
     :log_path, # for logger
@@ -13,13 +17,22 @@ module MailRoom
 
   # Holds configuration for each of the email accounts we wish to monitor
   #   and deliver email to when new emails arrive over imap
-  Mailbox = Struct.new(*FIELDS) do
+  Mailbox = Struct.new(*MAILBOX_FIELDS) do
+    # Default attributes for the mailbox configuration
+    DEFAULTS = {
+      :search_command => 'UNSEEN',
+      :delivery_method => 'postback',
+      :host => 'imap.gmail.com',
+      :port => 993,
+      :ssl => true
+    }
+
     # Store the configuration and require the appropriate delivery method
     # @param attributes [Hash] configuration options
     def initialize(attributes={})
-      super(*attributes.values_at(*members))
+      super(*DEFAULTS.merge(attributes).values_at(*members))
 
-      require_relative("./delivery/#{(delivery_method || 'postback')}")
+      require_relative("./delivery/#{(delivery_method)}")
     end
 
     # move to a mailbox deliverer class?

--- a/lib/mail_room/mailbox_handler.rb
+++ b/lib/mail_room/mailbox_handler.rb
@@ -39,7 +39,7 @@ module MailRoom
     # search for all new (unseen) message ids
     # @return [Array<Integer>] message ids
     def new_message_ids
-      @imap.search('UNSEEN')
+      @imap.search(@mailbox.search_command)
     end
 
     # @private

--- a/lib/mail_room/mailbox_watcher.rb
+++ b/lib/mail_room/mailbox_watcher.rb
@@ -17,7 +17,7 @@ module MailRoom
 
     # build a net/imap connection to google imap
     def imap
-      @imap ||= Net::IMAP.new('imap.gmail.com', :port => 993, :ssl => true)
+      @imap ||= Net::IMAP.new(@mailbox.host, :port => @mailbox.port, :ssl => @mailbox.ssl)
     end
 
     # build a handler to process mailbox messages

--- a/spec/lib/mailbox_handler_spec.rb
+++ b/spec/lib/mailbox_handler_spec.rb
@@ -22,12 +22,13 @@ describe MailRoom::MailboxHandler do
     it 'returns no messages if there are no ids' do
       imap.stubs(:search).returns([])
       imap.stubs(:fetch)
+      mailbox.search_command = 'NEW'
       mailbox.stubs(:deliver)
 
       handler = MailRoom::MailboxHandler.new(mailbox, imap)
       handler.process
 
-      imap.should have_received(:search).with('UNSEEN')
+      imap.should have_received(:search).with('NEW')
       imap.should have_received(:fetch).never
       mailbox.should have_received(:deliver).never
     end

--- a/spec/lib/mailbox_watcher_spec.rb
+++ b/spec/lib/mailbox_watcher_spec.rb
@@ -23,10 +23,12 @@ describe MailRoom::MailboxWatcher do
   end
 
   describe '#imap' do
+    let(:mailbox) {MailRoom::Mailbox.new}
+
     it 'builds a new Net::IMAP object' do
       Net::IMAP.stubs(:new).returns('imap')
 
-      MailRoom::MailboxWatcher.new(nil).imap.should eq('imap')
+      MailRoom::MailboxWatcher.new(mailbox).imap.should eq('imap')
 
       Net::IMAP.should have_received(:new).with('imap.gmail.com', :port => 993, :ssl => true)
     end


### PR DESCRIPTION
Adds configuration for:

* host (defaults to imap.gmail.com)
* port (defaults to 993)
* ssl (defaults to true)
* search_command (defaults to 'UNSEEN')