### PR TITLE
Add Sidekiq delivery method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
     :delivery_method: letter_opener
     :delivery_options:
       :location: "/tmp/user4-email"
+  -
+    :email: "user5@gmail.com"
+    :password: "password"
+    :name: "inbox"
+    :delivery_method: sidekiq
+    :delivery_options:
+      :redis_url: redis://localhost:6379
+      :worker: EmailReceiverWorker
 ```
 
 ## delivery_method ##
@@ -82,6 +90,39 @@ As the postback is essentially using your app as if it were an API endpoint,
 you may need to disable forgery protection as you would with a JSON API. In 
 our case, the postback is plaintext, but the protection will still need to be 
 disabled.
+
+### sidekiq ###
+
+Deliver the message by pushing it onto the configured Sidekiq queue to be handled by a custom worker.
+
+Requires `redis` gem to be installed.
+
+Configured with `:delivery_method: sidekiq`.
+
+Delivery options:
+- **redis_url**: The Redis server to connect with. Use the same Redis URL that's used to configure Sidekiq.
+  Required, defaults to `redis://localhost:6379`.
+- **namespace**: The Redis namespace Sidekiq works under. Use the same Redis namespace that's used to configure Sidekiq.
+  Optional.
+- **queue**: The Sidekiq queue the job is pushed onto. Make sure Sidekiq actually reads off this queue.
+  Required, defaults to `default`.
+- **worker**: The worker class that will handle the message.
+  Required.
+
+An example worker implementation looks like this:
+
+
+```ruby
+class EmailReceiverWorker
+  include Sidekiq::Worker
+
+  def perform(message)
+    mail = Mail::Message.new(message)
+
+    puts "New mail from #{mail.from.first}: #{mail.subject}"
+  end
+end
+```
 
 ### logger ###
 
@@ -117,7 +158,9 @@ This setting allows configuration of the IMAP search command sent to the server.
 
 ## IMAP Server Configuration ##
 
-You can set per-mailbox configuration for the IMAP server's `host` (default: 'imap.gmail.com'), `port` (default: 993), and `ssl` (default: true).
+You can set per-mailbox configuration for the IMAP server's `host` (default: 'imap.gmail.com'), `port` (default: 993), and `ssl` (default: true). 
+
+If you're seeing the error `Please log in via your web browser: https://support.google.com/mail/accounts/answer/78754 (Failure)`, you need to configure your Gmail account to allow less secure apps to access it: https://support.google.com/accounts/answer/6010255.
 
 ## Running in Production ##
 

--- a/lib/mail_room/delivery/sidekiq.rb
+++ b/lib/mail_room/delivery/sidekiq.rb
@@ -1,0 +1,64 @@
+require "redis"
+require "securerandom"
+require "json"
+
+module MailRoom
+  module Delivery
+    # Postback Delivery method
+    # @author Tony Pitale
+    class Sidekiq
+      Options = Struct.new(:redis_url, :namespace, :queue, :worker) do
+        def initialize(mailbox)
+          redis_url = mailbox.delivery_options[:redis_url]
+          namespace = mailbox.delivery_options[:namespace]
+          queue     = mailbox.delivery_options[:queue]  || "default"
+          worker    = mailbox.delivery_options[:worker] || "redis://localhost:6379"
+
+          super(redis_url, namespace, queue, worker)
+        end
+      end
+
+      attr_accessor :options
+
+      # Build a new delivery, hold the mailbox configuration
+      # @param [MailRoom::Mailbox]
+      def initialize(options)
+        @options = options
+      end
+
+      # deliver the message by pushing it onto the configured Sidekiq queue
+      # @param message [String] the email message as a string, RFC822 format
+      def deliver(message)
+        item = item_for(message)
+
+        client.lpush("queue:#{options.queue}", JSON.generate(item))
+      end
+
+      private
+
+      def client
+        client = Redis.new(url: options.redis_url)
+
+        namespace = options.namespace
+        if namespace
+          require 'redis/namespace'
+          Redis::Namespace.new(namespace, redis: client)
+        else
+          client
+        end
+      end
+
+      def item_for(message)
+        {
+          'class'       => options.worker,
+          'args'        => [message],
+
+          'queue'       => options.queue,
+          'jid'         => SecureRandom.hex(12),
+          'retry'       => false,
+          'enqueued_at' => Time.now.to_f
+        }
+      end
+    end
+  end
+end

--- a/lib/mail_room/delivery/sidekiq.rb
+++ b/lib/mail_room/delivery/sidekiq.rb
@@ -32,6 +32,8 @@ module MailRoom
         item = item_for(message)
 
         client.lpush("queue:#{options.queue}", JSON.generate(item))
+
+        true
       end
 
       private

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -46,6 +46,8 @@ module MailRoom
         Delivery::Logger
       when "letter_opener"
         Delivery::LetterOpener
+      when "sidekiq"
+        Delivery::Sidekiq
       else
         Delivery::Postback
       end

--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "faraday"
   gem.add_development_dependency "mail"
   gem.add_development_dependency "letter_opener"
+  gem.add_development_dependency "redis"
 end


### PR DESCRIPTION
This adds a Sidekiq delivery method that will deliver the message by pushing it onto the configured Sidekiq queue to be handled by a custom worker.

We're planning to use this in GitLab 8.0, due to be released on September 22nd, so if this could go into a new gem release before then, that would be awesome.