### PR TITLE
Extend delivery options with method-specific options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,28 +34,33 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
     :email: "user1@gmail.com"
     :password: "password"
     :name: "inbox"
-    :delivery_url: "http://localhost:3000/inbox"
-    :delivery_token: "abcdefg"
     :search_command: 'NEW'
+    :delivery_options:
+      :delivery_url: "http://localhost:3000/inbox"
+      :delivery_token: "abcdefg"
+    
   -
     :email: "user2@gmail.com"
     :password: "password"
     :name: "inbox"
     :delivery_method: postback
-    :delivery_url: "http://localhost:3000/inbox"
-    :delivery_token: "abcdefg"
+    :delivery_options:
+      :delivery_url: "http://localhost:3000/inbox"
+      :delivery_token: "abcdefg"
   -
     :email: "user3@gmail.com"
     :password: "password"
     :name: "inbox"
     :delivery_method: logger
-    :log_path: "/var/log/user3-email.log"
+    :delivery_options:
+      :log_path: "/var/log/user3-email.log"
   -
     :email: "user4@gmail.com"
     :password: "password"
     :name: "inbox"
     :delivery_method: letter_opener
-    :location: "/tmp/user4-email"
+    :delivery_options:
+      :location: "/tmp/user4-email"
 ```
 
 ## delivery_method ##

--- a/lib/mail_room/delivery/letter_opener.rb
+++ b/lib/mail_room/delivery/letter_opener.rb
@@ -7,16 +7,24 @@ module MailRoom
     # LetterOpener Delivery method
     # @author Tony Pitale
     class LetterOpener
-      # Build a new delivery, hold the mailbox configuration
-      # @param [MailRoom::Mailbox]
-      def initialize(mailbox)
-        @mailbox = mailbox
+      Options = Struct.new(:location) do
+        def initialize(mailbox)
+          location = mailbox.location || mailbox.delivery_options[:location]
+
+          super(location)
+        end
+      end
+
+      # Build a new delivery, hold the delivery options
+      # @param [MailRoom::Delivery::LetterOpener::Options]
+      def initialize(delivery_options)
+        @delivery_options = delivery_options
       end
 
       # Trigger `LetterOpener` to deliver our message
       # @param message [String] the email message as a string, RFC822 format
       def deliver(message)
-        method = ::LetterOpener::DeliveryMethod.new(:location => @mailbox.location)
+        method = ::LetterOpener::DeliveryMethod.new(:location => @delivery_options.location)
         method.deliver!(Mail.read_from_string(message))
       end
     end

--- a/lib/mail_room/delivery/logger.rb
+++ b/lib/mail_room/delivery/logger.rb
@@ -5,11 +5,19 @@ module MailRoom
     # File/STDOUT Logger Delivery method
     # @author Tony Pitale
     class Logger
-      # Build a new delivery, hold the mailbox configuration
-      #   open a file or stdout for IO depending on the configuration
-      # @param [MailRoom::Mailbox]
-      def initialize(mailbox)
-        io = File.open(mailbox.log_path, 'a') if mailbox.log_path
+      Options = Struct.new(:log_path) do
+        def initialize(mailbox)
+          log_path = mailbox.log_path || mailbox.delivery_options[:log_path]
+
+          super(log_path)
+        end
+      end
+
+      # Build a new delivery, hold the delivery options
+      #   open a file or stdout for IO depending on the options
+      # @param [MailRoom::Delivery::Logger::Options]
+      def initialize(delivery_options)
+        io = File.open(delivery_options.log_path, 'a') if delivery_options.log_path
         io ||= STDOUT
 
         io.sync = true

--- a/lib/mail_room/delivery/noop.rb
+++ b/lib/mail_room/delivery/noop.rb
@@ -3,6 +3,12 @@ module MailRoom
     # Noop Delivery method
     # @author Tony Pitale
     class Noop
+      Options = Class.new do
+        def initialize(*)
+          super()
+        end
+      end
+
       # build a new delivery, do nothing
       def initialize(*)
       end

--- a/lib/mail_room/delivery/postback.rb
+++ b/lib/mail_room/delivery/postback.rb
@@ -5,20 +5,29 @@ module MailRoom
     # Postback Delivery method
     # @author Tony Pitale
     class Postback
-      # Build a new delivery, hold the mailbox configuration
-      # @param [MailRoom::Mailbox]
-      def initialize(mailbox)
-        @mailbox = mailbox
+      Options = Struct.new(:delivery_url, :delivery_token) do
+        def initialize(mailbox)
+          delivery_url = mailbox.delivery_url || mailbox.delivery_options[:delivery_url]
+          delivery_token = mailbox.delivery_token || mailbox.delivery_options[:delivery_token]
+
+          super(delivery_url, delivery_token)
+        end
       end
 
-      # deliver the message using Faraday to the configured mailbox url
+      # Build a new delivery, hold the delivery options
+      # @param [MailRoom::Delivery::Postback::Options]
+      def initialize(delivery_options)
+        @delivery_options = delivery_options
+      end
+
+      # deliver the message using Faraday to the configured delivery_options url
       # @param message [String] the email message as a string, RFC822 format
       def deliver(message)
         connection = Faraday.new
-        connection.token_auth @mailbox.delivery_token
+        connection.token_auth @delivery_options.delivery_token
 
         connection.post do |request|
-          request.url @mailbox.delivery_url
+          request.url @delivery_options.delivery_url
           request.body = message
           # request.options[:timeout] = 3
           # request.headers['Content-Type'] = 'text/plain'

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -12,7 +12,8 @@ module MailRoom
     :log_path, # for logger
     :delivery_url, # for postback
     :delivery_token, # for postback
-    :location # for letter_opener
+    :location, # for letter_opener
+    :delivery_options
   ]
 
   # Holds configuration for each of the email accounts we wish to monitor
@@ -24,7 +25,8 @@ module MailRoom
       :delivery_method => 'postback',
       :host => 'imap.gmail.com',
       :port => 993,
-      :ssl => true
+      :ssl => true,
+      :delivery_options => {}
     }
 
     # Store the configuration and require the appropriate delivery method
@@ -52,7 +54,12 @@ module MailRoom
     # deliver the imap email message
     # @param message [Net::IMAP::FetchData]
     def deliver(message)
-      delivery_klass.new(self).deliver(message.attr['RFC822'])
+      delivery_klass.new(parsed_delivery_options).deliver(message.attr['RFC822'])
+    end
+
+    private
+    def parsed_delivery_options
+      delivery_klass::Options.new(self)
     end
   end
 end


### PR DESCRIPTION
Resolves the configuration extension portion of https://github.com/tpitale/mail_room/pull/24 by using delivery-method-specific options structs. This way, folks get errors when they use the wrong options. Should also support the previous flat structure for existing configurations.