### PR TITLE
Optionally process a mailbox before first idling for a new message

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
     :email: "user1@gmail.com"
     :password: "password"
     :name: "inbox"
+    :prefetch_messages: false # default
     :delivery_url: "http://localhost:3000/inbox"
     :delivery_token: "abcdefg"
     :search_command: 'NEW'
@@ -41,6 +42,7 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
     :email: "user2@gmail.com"
     :password: "password"
     :name: "inbox"
+    :prefetch_messages: true # get mail before first idle
     :delivery_method: postback
     :delivery_url: "http://localhost:3000/inbox"
     :delivery_token: "abcdefg"

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -7,6 +7,7 @@ module MailRoom
     :port,
     :ssl,
     :search_command,
+    :prefetch_messages,
     :name,
     :delivery_method, # :noop, :logger, :postback, :letter_opener
     :log_path, # for logger
@@ -20,6 +21,7 @@ module MailRoom
   Mailbox = Struct.new(*MAILBOX_FIELDS) do
     # Default attributes for the mailbox configuration
     DEFAULTS = {
+      :prefetch_messages => false,
       :search_command => 'UNSEEN',
       :delivery_method => 'postback',
       :host => 'imap.gmail.com',

--- a/lib/mail_room/mailbox_watcher.rb
+++ b/lib/mail_room/mailbox_watcher.rb
@@ -25,6 +25,12 @@ module MailRoom
       @handler ||= MailboxHandler.new(@mailbox, imap)
     end
 
+    # do we want to process this mailbox before idling
+    # @return [Boolean]
+    def prefetch_messages?
+      @mailbox.prefetch_messages
+    end
+
     # are we running?
     # @return [Boolean]
     def running?
@@ -112,6 +118,8 @@ module MailRoom
       setup
 
       @running = true
+
+      process_mailbox if prefetch_messages?
 
       self.idling_thread = Thread.start do
         while(running?) do

--- a/spec/lib/mailbox_watcher_spec.rb
+++ b/spec/lib/mailbox_watcher_spec.rb
@@ -1,23 +1,25 @@
 require 'spec_helper'
 
 describe MailRoom::MailboxWatcher do
+  let(:mailbox) {stub(:prefetch_messages => false)}
+
   describe '#running?' do
     it 'is false by default' do
-      watcher = MailRoom::MailboxWatcher.new(nil)
+      watcher = MailRoom::MailboxWatcher.new(mailbox)
       watcher.running?.should eq(false)
     end
   end
 
   describe '#logged_in?' do
     it 'is false by default' do
-      watcher = MailRoom::MailboxWatcher.new(nil)
+      watcher = MailRoom::MailboxWatcher.new(mailbox)
       watcher.logged_in?.should eq(false)
     end
   end
 
   describe '#idling?' do
     it 'is false by default' do
-      watcher = MailRoom::MailboxWatcher.new(nil)
+      watcher = MailRoom::MailboxWatcher.new(mailbox)
       watcher.idling?.should eq(false)
     end
   end
@@ -159,7 +161,7 @@ describe MailRoom::MailboxWatcher do
   end
 
   describe '#run' do
-    let(:watcher) {MailRoom::MailboxWatcher.new(nil)}
+    let(:watcher) {MailRoom::MailboxWatcher.new(mailbox)}
 
     before :each do
       Thread.stubs(:start).yields.returns(stub(:abort_on_exception=))
@@ -217,7 +219,7 @@ describe MailRoom::MailboxWatcher do
   end
 
   describe '#quit' do
-    let(:watcher) {MailRoom::MailboxWatcher.new(nil)}
+    let(:watcher) {MailRoom::MailboxWatcher.new(mailbox)}
 
     it 'stops idling' do
       watcher.stubs(:stop_idling)


### PR DESCRIPTION
This maintains the default as `false` to maintain any expectations users have of past behavior.

Extracted from https://github.com/tpitale/mail_room/pull/24 /cc @DouweM