### PR TITLE
Skip fetchdata without a body.

### DIFF
--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -58,7 +58,10 @@ module MailRoom
     # deliver the imap email message
     # @param message [Net::IMAP::FetchData]
     def deliver(message)
-      delivery_klass.new(parsed_delivery_options).deliver(message.attr['RFC822'])
+      message = message.attr['RFC822']
+      return true unless message
+      
+      delivery_klass.new(parsed_delivery_options).deliver(message)
     end
 
     private

--- a/spec/lib/mailbox_spec.rb
+++ b/spec/lib/mailbox_spec.rb
@@ -49,5 +49,17 @@ describe MailRoom::Mailbox do
         letter_opener.should have_received(:deliver).with('a message')
       end
     end
+
+    context "without an RFC822 attribute" do
+      it "doesn't deliver the message" do
+        mailbox = MailRoom::Mailbox.new({:delivery_method => 'noop'})
+        noop = stub(:deliver)
+        MailRoom::Delivery::Noop.stubs(:new => noop)
+
+        mailbox.deliver(stub(:attr => {'FLAGS' => [:Seen, :Recent]}))
+
+        noop.should have_received(:deliver).never
+      end
+    end
   end
 end


### PR DESCRIPTION
For some reason, MailRoom was getting fetch data like this from `new_messages`, after every actual message:

```
#<struct Net::IMAP::FetchData seqno=5, attr={"FLAGS"=>[:Seen, :Recent]}>
```

Since this doesn't have an `RFC822` attribute, the message passed to the handler would be `nil`.

I'm not completely sure why we're getting these fetchdatas at all, since we clearly only do `fetch(ids, "RFC822")`, but it must be some Postfix/Courier oddity that we can work around like this.