### PR TITLE
Re-setup on all IOErrors

### DIFF
--- a/lib/mail_room/mailbox_watcher.rb
+++ b/lib/mail_room/mailbox_watcher.rb
@@ -124,7 +124,7 @@ module MailRoom
 
             # when new messages are ready
             process_mailbox
-          rescue Net::IMAP::Error, EOFError => e
+          rescue Net::IMAP::Error, IOError => e
             # we've been disconnected, so re-setup
             setup
           end


### PR DESCRIPTION
We were seeing mail_room crash because of a `closed stream (IOError)`:

```ruby
/usr/local/lib/ruby/2.1.0/net/imap.rb:1225:in `write': closed stream (IOError)
    from /usr/local/lib/ruby/2.1.0/net/imap.rb:1225:in `print'
    from /usr/local/lib/ruby/2.1.0/net/imap.rb:1225:in `put_string'
    from /usr/local/lib/ruby/2.1.0/net/imap.rb:1197:in `block in send_command'
    from /usr/local/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
    from /usr/local/lib/ruby/2.1.0/net/imap.rb:1192:in `send_command'
    from /usr/local/lib/ruby/2.1.0/net/imap.rb:1345:in `block in search_internal'
    from /usr/local/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
    from /usr/local/lib/ruby/2.1.0/net/imap.rb:1341:in `search_internal'
    from /usr/local/lib/ruby/2.1.0/net/imap.rb:768:in `search'
    from /home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/mail_room-0.4.1/lib/mail_room/mailbox_handler.rb:48:in `new_message_ids'
    from /home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/mail_room-0.4.1/lib/mail_room/mailbox_handler.rb:38:in `new_messages'
    from /home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/mail_room-0.4.1/lib/mail_room/mailbox_handler.rb:17:in `process'
    from /home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/mail_room-0.4.1/lib/mail_room/mailbox_watcher.rb:146:in `process_mailbox'
    from /home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/mail_room-0.4.1/lib/mail_room/mailbox_watcher.rb:126:in `block in run'
```