### PR TITLE
Re-idle after 29 minutes to prevent server from closing connection

### DIFF
--- a/lib/mail_room/mailbox_watcher.rb
+++ b/lib/mail_room/mailbox_watcher.rb
@@ -95,8 +95,9 @@ module MailRoom
       @idling = true
 
       self.timeout_thread = Thread.start do
-        # The IMAP server will close the connection after 30 minutes, so re-idle
-        # every 29 minutes, as suggested by the spec: https://tools.ietf.org/html/rfc2177
+        # The IMAP server will close the connection after 30 minutes of inactivity
+        # (which sending IDLE and then nothing technically is), so we re-idle every
+        # 29 minutes, as suggested by the spec: https://tools.ietf.org/html/rfc2177
         sleep 29 * 60
 
         imap.idle_done if idling?


### PR DESCRIPTION
The IMAP server will close the connection after 30 minutes of inactivity (which sending IDLE and then nothing technically is), so we re-idle every 29 minutes, as suggested by the spec: https://tools.ietf.org/html/rfc2177

We were seeing Reply by email work perfectly after (re)starting the server, and then not doing anything after 30 minutes had passed.