### PR TITLE
Add arbitration for situations where multiple mail_rooms are watching the same inbox.

### DIFF
--- a/lib/mail_room.rb
+++ b/lib/mail_room.rb
@@ -2,16 +2,7 @@ require 'net/imap'
 require 'optparse'
 require 'yaml'
 
-# The MailRoom namespace
 module MailRoom
-  # The MailRoom Delivery namespace holds any defined delivery methods
-  #   including:
-  # 
-  #   * postback (default)
-  #   * letter_opener
-  #   * logger
-  #   * noop
-  module Delivery; end
 end
 
 require "mail_room/version"

--- a/lib/mail_room/arbitration.rb
+++ b/lib/mail_room/arbitration.rb
@@ -1,0 +1,14 @@
+module MailRoom
+  module Arbitration
+    def self.[](name)
+      require_relative("./arbitration/#{name}")
+
+      case name
+      when "redis"
+        Arbitration::Redis
+      else
+        Arbitration::Noop
+      end
+    end
+  end
+end

--- a/lib/mail_room/arbitration.rb
+++ b/lib/mail_room/arbitration.rb
@@ -1,6 +1,6 @@
 module MailRoom
   module Arbitration
-    def self.[](name)
+    def [](name)
       require_relative("./arbitration/#{name}")
 
       case name
@@ -10,5 +10,7 @@ module MailRoom
         Arbitration::Noop
       end
     end
+
+    module_function :[]
   end
 end

--- a/lib/mail_room/arbitration/noop.rb
+++ b/lib/mail_room/arbitration/noop.rb
@@ -1,0 +1,18 @@
+module MailRoom
+  module Arbitration
+    class Noop
+      Options = Class.new do
+        def initialize(*)
+          super()
+        end
+      end
+
+      def initialize(*)
+      end
+
+      def deliver?(*)
+        true
+      end
+    end
+  end
+end

--- a/lib/mail_room/arbitration/redis.rb
+++ b/lib/mail_room/arbitration/redis.rb
@@ -12,6 +12,9 @@ module MailRoom
         end
       end
 
+      # Expire after 10 minutes so Redis doesn't get filled up with outdated data.
+      EXPIRATION = 600
+
       attr_accessor :options
 
       # Build a new delivery, hold the mailbox configuration
@@ -30,8 +33,7 @@ module MailRoom
           # the MULTI command returns.
           incr = client.incr(key)
 
-          # Expire after 1 minute so Redis doesn't get filled up with outdated data.
-          client.expire(key, 60)
+          client.expire(key, EXPIRATION)
         end
 
         incr.value == 1

--- a/lib/mail_room/arbitration/redis.rb
+++ b/lib/mail_room/arbitration/redis.rb
@@ -17,8 +17,6 @@ module MailRoom
 
       attr_accessor :options
 
-      # Build a new delivery, hold the mailbox configuration
-      # @param [MailRoom::Delivery::Sidekiq::Options]
       def initialize(options)
         @options = options
       end

--- a/lib/mail_room/arbitration/redis.rb
+++ b/lib/mail_room/arbitration/redis.rb
@@ -36,6 +36,10 @@ module MailRoom
           client.expire(key, EXPIRATION)
         end
 
+        # If INCR returns 1, that means the key didn't exist before, which means
+        # we are the first mail_room to try to deliver this message, so we get to.
+        # If we get any other value, another mail_room already (tried to) deliver
+        # the message, so we don't have to anymore.
         incr.value == 1
       end
 

--- a/lib/mail_room/arbitration/redis.rb
+++ b/lib/mail_room/arbitration/redis.rb
@@ -23,8 +23,7 @@ module MailRoom
         @options = options
       end
 
-      def deliver?(message)
-        uid = message.attr["UID"]
+      def deliver?(uid)
         key = "delivered:#{uid}"
 
         incr = nil

--- a/lib/mail_room/arbitration/redis.rb
+++ b/lib/mail_room/arbitration/redis.rb
@@ -1,0 +1,57 @@
+require "redis"
+
+module MailRoom
+  module Arbitration
+    class Redis
+      Options = Struct.new(:redis_url, :namespace) do
+        def initialize(mailbox)
+          redis_url = mailbox.arbitration_options[:redis_url] || "redis://localhost:6379"
+          namespace = mailbox.arbitration_options[:namespace]
+
+          super(redis_url, namespace)
+        end
+      end
+
+      attr_accessor :options
+
+      # Build a new delivery, hold the mailbox configuration
+      # @param [MailRoom::Delivery::Sidekiq::Options]
+      def initialize(options)
+        @options = options
+      end
+
+      def deliver?(message)
+        uid = message.attr["UID"]
+        key = "delivered:#{uid}"
+
+        incr = nil
+        redis.multi do |client|
+          # At this point, `incr` is a future, which will get its value after 
+          # the MULTI command returns.
+          incr = client.incr(key)
+
+          # Expire after 1 minute so Redis doesn't get filled up with outdated data.
+          client.expire(key, 60)
+        end
+
+        incr.value == 1
+      end
+
+      private
+
+      def redis
+        @redis ||= begin
+          redis = ::Redis.new(url: options.redis_url)
+
+          namespace = options.namespace
+          if namespace
+            require 'redis/namespace'
+            ::Redis::Namespace.new(namespace, redis: redis)
+          else
+            redis
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mail_room/delivery.rb
+++ b/lib/mail_room/delivery.rb
@@ -1,6 +1,6 @@
 module MailRoom
   module Delivery
-    def self.[](name)
+    def [](name)
       require_relative("./delivery/#{name}")
 
       case name
@@ -18,5 +18,7 @@ module MailRoom
         Delivery::Noop
       end
     end
+
+    module_function :[]
   end
 end

--- a/lib/mail_room/delivery.rb
+++ b/lib/mail_room/delivery.rb
@@ -1,0 +1,22 @@
+module MailRoom
+  module Delivery
+    def self.[](name)
+      require_relative("./delivery/#{name}")
+
+      case name
+      when "postback"
+        Delivery::Postback
+      when "logger"
+        Delivery::Logger
+      when "letter_opener"
+        Delivery::LetterOpener
+      when "sidekiq"
+        Delivery::Sidekiq
+      when "que"
+        Delivery::Que
+      else
+        Delivery::Noop
+      end
+    end
+  end
+end

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -1,3 +1,6 @@
+require "mail_room/delivery"
+require "mail_room/arbitration"
+
 module MailRoom
   # Mailbox Configuration fields
   MAILBOX_FIELDS = [
@@ -15,7 +18,9 @@ module MailRoom
     :delivery_url, # for postback
     :delivery_token, # for postback
     :location, # for letter_opener
-    :delivery_options
+    :delivery_options,
+    :arbitration_method,
+    :arbitration_options
   ]
 
   # Holds configuration for each of the email accounts we wish to monitor
@@ -30,47 +35,44 @@ module MailRoom
       :ssl => true,
       :start_tls => false,
       :delete_after_delivery => false,
-      :delivery_options => {}
+      :delivery_options => {},
+      :arbitration_method => 'noop',
+      :arbitration_options => {}
     }
 
     # Store the configuration and require the appropriate delivery method
     # @param attributes [Hash] configuration options
     def initialize(attributes={})
       super(*DEFAULTS.merge(attributes).values_at(*members))
-
-      require_relative("./delivery/#{(delivery_method)}")
     end
 
-    # move to a mailbox deliverer class?
-    def delivery_klass
-      case delivery_method
-      when "noop"
-        Delivery::Noop
-      when "logger"
-        Delivery::Logger
-      when "letter_opener"
-        Delivery::LetterOpener
-      when "sidekiq"
-        Delivery::Sidekiq
-      when "que"
-        Delivery::Que
-      else
-        Delivery::Postback
-      end
+    def delivery
+      @delivery ||= Delivery[delivery_method].new(parsed_delivery_options)
+    end
+
+    def arbitrator
+      @arbitrator ||= Arbitration[arbitration_method].new(parsed_arbitration_options)
     end
 
     # deliver the imap email message
     # @param message [Net::IMAP::FetchData]
     def deliver(message)
-      message = message.attr['RFC822']
-      return true unless message
-      
-      delivery_klass.new(parsed_delivery_options).deliver(message)
+      body = message.attr['RFC822']
+      return true unless body
+
+      return false unless arbitrator.deliver?(message)
+
+      delivery.deliver(body)
     end
 
     private
+
+    def parsed_arbitration_options
+      Arbitration[arbitration_method]::Options.new(self)
+    end
+
     def parsed_delivery_options
-      delivery_klass::Options.new(self)
+      Delivery[delivery_method]::Options.new(self)
     end
   end
 end

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -62,13 +62,15 @@ module MailRoom
       @arbitrator ||= arbitration_klass.new(parsed_arbitration_options)
     end
 
+    def deliver?(uid)
+      arbitrator.deliver?(uid)
+    end
+
     # deliver the imap email message
     # @param message [Net::IMAP::FetchData]
     def deliver(message)
       body = message.attr['RFC822']
       return true unless body
-
-      return false unless arbitrator.deliver?(message)
 
       delivery.deliver(body)
     end

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -46,12 +46,20 @@ module MailRoom
       super(*DEFAULTS.merge(attributes).values_at(*members))
     end
 
+    def delivery_klass
+      Delivery[delivery_method]
+    end
+
+    def arbitration_klass
+      Arbitration[arbitration_method]
+    end
+
     def delivery
-      @delivery ||= Delivery[delivery_method].new(parsed_delivery_options)
+      @delivery ||= delivery_klass.new(parsed_delivery_options)
     end
 
     def arbitrator
-      @arbitrator ||= Arbitration[arbitration_method].new(parsed_arbitration_options)
+      @arbitrator ||= arbitration_klass.new(parsed_arbitration_options)
     end
 
     # deliver the imap email message
@@ -68,11 +76,11 @@ module MailRoom
     private
 
     def parsed_arbitration_options
-      Arbitration[arbitration_method]::Options.new(self)
+      arbitration_klass::Options.new(self)
     end
 
     def parsed_delivery_options
-      Delivery[delivery_method]::Options.new(self)
+      delivery_klass::Options.new(self)
     end
   end
 end

--- a/lib/mail_room/mailbox_handler.rb
+++ b/lib/mail_room/mailbox_handler.rb
@@ -43,9 +43,7 @@ module MailRoom
     # search for all new (unseen) message ids
     # @return [Array<Integer>] message ids
     def new_message_ids
-      uids = @imap.uid_search(@mailbox.search_command)
-      uids.select! { |uid| @mailbox.deliver?(uid) }
-      uids
+      @imap.uid_search(@mailbox.search_command).select { |uid| @mailbox.deliver?(uid) }
     end
 
     # @private

--- a/lib/mail_room/mailbox_handler.rb
+++ b/lib/mail_room/mailbox_handler.rb
@@ -14,14 +14,12 @@ module MailRoom
     def process
       # return if idling? || !running?
 
-      new_messages.each do |msg|
-        # puts msg.attr['RFC822']
-
+      new_messages.each do |message|
         # loop over delivery methods and deliver each
-        delivered = @mailbox.deliver(msg)
+        delivered = @mailbox.deliver(message)
 
         if delivered && @mailbox.delete_after_delivery
-          @imap.store(msg.seqno, "+FLAGS", [Net::IMAP::DELETED])
+          @imap.store(message.seqno, "+FLAGS", [Net::IMAP::DELETED])
         end
       end
 
@@ -55,7 +53,7 @@ module MailRoom
     def messages_for_ids(ids)
       return [] if ids.empty?
 
-      @imap.fetch(ids, "RFC822")
+      @imap.fetch(ids, ["RFC822", "UID"])
     end
   end
 end

--- a/lib/mail_room/mailbox_handler.rb
+++ b/lib/mail_room/mailbox_handler.rb
@@ -43,17 +43,21 @@ module MailRoom
     # search for all new (unseen) message ids
     # @return [Array<Integer>] message ids
     def new_message_ids
-      @imap.search(@mailbox.search_command)
+      uids = @imap.uid_search(@mailbox.search_command)
+      puts "New message ids: #{uids}"
+      uids.select! { |uid| @mailbox.deliver?(uid) }
+      puts "Deliverable uids: #{uids}"
+      uids
     end
 
     # @private
     # fetch the email for all given ids in RFC822 format
     # @param ids [Array<Integer>] list of message ids
     # @return [Array<Net::IMAP::FetchData>] the net/imap messages for the given ids
-    def messages_for_ids(ids)
-      return [] if ids.empty?
+    def messages_for_ids(uids)
+      return [] if uids.empty?
 
-      @imap.fetch(ids, ["RFC822", "UID"])
+      @imap.uid_fetch(uids, "RFC822")
     end
   end
 end

--- a/lib/mail_room/mailbox_handler.rb
+++ b/lib/mail_room/mailbox_handler.rb
@@ -44,9 +44,7 @@ module MailRoom
     # @return [Array<Integer>] message ids
     def new_message_ids
       uids = @imap.uid_search(@mailbox.search_command)
-      puts "New message ids: #{uids}"
       uids.select! { |uid| @mailbox.deliver?(uid) }
-      puts "Deliverable uids: #{uids}"
       uids
     end
 

--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -22,12 +22,13 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "bourne"
   gem.add_development_dependency "simplecov"
+  gem.add_development_dependency "fakeredis"
 
   # for testing delivery methods
   gem.add_development_dependency "faraday"
   gem.add_development_dependency "mail"
   gem.add_development_dependency "letter_opener"
-  gem.add_development_dependency "redis"
+  gem.add_development_dependency "redis-namespace"
   gem.add_development_dependency "pg"
   gem.add_development_dependency "charlock_holmes"
 end

--- a/spec/lib/arbitration/redis_spec.rb
+++ b/spec/lib/arbitration/redis_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'mail_room/arbitration/redis'
+
+describe MailRoom::Arbitration::Redis do
+  describe '#deliver?' do
+    let(:mailbox) { MailRoom::Mailbox.new }
+
+    # TODO
+  end
+end

--- a/spec/lib/arbitration/redis_spec.rb
+++ b/spec/lib/arbitration/redis_spec.rb
@@ -2,9 +2,62 @@ require 'spec_helper'
 require 'mail_room/arbitration/redis'
 
 describe MailRoom::Arbitration::Redis do
-  describe '#deliver?' do
-    let(:mailbox) { MailRoom::Mailbox.new }
+  let(:mailbox) { 
+    MailRoom::Mailbox.new(
+      arbitration_options: {
+        namespace: "mail_room"
+      }
+    ) 
+  }
+  let(:options) { described_class::Options.new(mailbox) }
+  subject       { described_class.new(options) }
 
-    # TODO
+  # Private, but we don't care.
+  let(:redis) { subject.send(:redis) }
+
+  describe '#deliver?' do
+    context "when called the first time" do
+      it "returns true" do
+        expect(subject.deliver?(123)).to be_truthy
+      end
+
+      it "increments the delivered flag" do
+        subject.deliver?(123)
+
+        expect(redis.get("delivered:123")).to eq("1")
+      end
+
+      it "sets an expiration on the delivered flag" do
+        subject.deliver?(123)
+
+        expect(redis.ttl("delivered:123")).to be > 0
+      end
+    end
+
+    context "when called the second time" do
+      before do
+        subject.deliver?(123)
+      end
+
+      it "returns false" do
+        expect(subject.deliver?(123)).to be_falsey
+      end
+
+      it "increments the delivered flag" do
+        subject.deliver?(123)
+
+        expect(redis.get("delivered:123")).to eq("2")
+      end
+    end
+
+    context "when called for another uid" do
+      before do
+        subject.deliver?(123)
+      end
+
+      it "returns true" do
+        expect(subject.deliver?(234)).to be_truthy
+      end
+    end
   end
 end

--- a/spec/lib/mailbox_handler_spec.rb
+++ b/spec/lib/mailbox_handler_spec.rb
@@ -21,6 +21,25 @@ describe MailRoom::MailboxHandler do
       mailbox.should have_received(:deliver).with(message2)
     end
 
+    it "fetches and delivers all new messages from ids that haven't been processed yet" do
+      imap.stubs(:uid_search).returns([1,2])
+      message1 = stub(:attr => {'RFC822' => 'message1'})
+      message2 = stub(:attr => {'RFC822' => 'message2'})
+      imap.stubs(:uid_fetch).returns([message2])
+      mailbox.stubs(:deliver)
+      mailbox.stubs(:deliver?).with(1).returns(false)
+      mailbox.stubs(:deliver?).with(2).returns(true)
+
+      handler = MailRoom::MailboxHandler.new(mailbox, imap)
+      handler.process
+
+      imap.should have_received(:uid_search).with('UNSEEN')
+      imap.should have_received(:uid_fetch).with([2], 'RFC822')
+
+      mailbox.should have_received(:deliver).with(message1).never
+      mailbox.should have_received(:deliver).with(message2)
+    end
+
     it 'returns no messages if there are no ids' do
       imap.stubs(:uid_search).returns([])
       imap.stubs(:uid_fetch)

--- a/spec/lib/mailbox_handler_spec.rb
+++ b/spec/lib/mailbox_handler_spec.rb
@@ -7,16 +7,18 @@ describe MailRoom::MailboxHandler do
 
     it 'fetches and delivers all new messages from ids' do
       imap.stubs(:search).returns([1,2])
-      imap.stubs(:fetch).returns(['message1', 'message2'])
+      message1 = stub(:attr => {'RFC822' => 'message1'})
+      message2 = stub(:attr => {'RFC822' => 'message2'})
+      imap.stubs(:fetch).returns([message1, message2])
       mailbox.stubs(:deliver)
 
       handler = MailRoom::MailboxHandler.new(mailbox, imap)
       handler.process
 
       imap.should have_received(:search).with('UNSEEN')
-      imap.should have_received(:fetch).with([1,2], 'RFC822')
-      mailbox.should have_received(:deliver).with('message1')
-      mailbox.should have_received(:deliver).with('message2')
+      imap.should have_received(:fetch).with([1,2], ['RFC822', 'UID'])
+      mailbox.should have_received(:deliver).with(message1)
+      mailbox.should have_received(:deliver).with(message2)
     end
 
     it 'returns no messages if there are no ids' do

--- a/spec/lib/mailbox_handler_spec.rb
+++ b/spec/lib/mailbox_handler_spec.rb
@@ -6,32 +6,32 @@ describe MailRoom::MailboxHandler do
     let(:mailbox) {MailRoom::Mailbox.new}
 
     it 'fetches and delivers all new messages from ids' do
-      imap.stubs(:search).returns([1,2])
+      imap.stubs(:uid_search).returns([1,2])
       message1 = stub(:attr => {'RFC822' => 'message1'})
       message2 = stub(:attr => {'RFC822' => 'message2'})
-      imap.stubs(:fetch).returns([message1, message2])
+      imap.stubs(:uid_fetch).returns([message1, message2])
       mailbox.stubs(:deliver)
 
       handler = MailRoom::MailboxHandler.new(mailbox, imap)
       handler.process
 
-      imap.should have_received(:search).with('UNSEEN')
-      imap.should have_received(:fetch).with([1,2], ['RFC822', 'UID'])
+      imap.should have_received(:uid_search).with('UNSEEN')
+      imap.should have_received(:uid_fetch).with([1,2], 'RFC822')
       mailbox.should have_received(:deliver).with(message1)
       mailbox.should have_received(:deliver).with(message2)
     end
 
     it 'returns no messages if there are no ids' do
-      imap.stubs(:search).returns([])
-      imap.stubs(:fetch)
+      imap.stubs(:uid_search).returns([])
+      imap.stubs(:uid_fetch)
       mailbox.search_command = 'NEW'
       mailbox.stubs(:deliver)
 
       handler = MailRoom::MailboxHandler.new(mailbox, imap)
       handler.process
 
-      imap.should have_received(:search).with('NEW')
-      imap.should have_received(:fetch).never
+      imap.should have_received(:uid_search).with('NEW')
+      imap.should have_received(:uid_fetch).never
       mailbox.should have_received(:deliver).never
     end
   end

--- a/spec/lib/mailbox_spec.rb
+++ b/spec/lib/mailbox_spec.rb
@@ -89,9 +89,5 @@ describe MailRoom::Mailbox do
         noop.should have_received(:deliver).never
       end
     end
-
-    describe "arbitration" do
-      # TODO
-    end
   end
 end

--- a/spec/lib/mailbox_spec.rb
+++ b/spec/lib/mailbox_spec.rb
@@ -8,11 +8,11 @@ describe MailRoom::Mailbox do
         noop = stub(:deliver?)
         MailRoom::Arbitration['noop'].stubs(:new => noop)
 
-        message = stub(:attr => {'RFC822' => 'a message'})
+        uid = 123
 
-        mailbox.deliver(message)
+        mailbox.deliver?(uid)
 
-        noop.should have_received(:deliver?).with(message)
+        noop.should have_received(:deliver?).with(uid)
       end
     end
 
@@ -22,11 +22,11 @@ describe MailRoom::Mailbox do
         redis = stub(:deliver?)
         MailRoom::Arbitration['redis'].stubs(:new => redis)
 
-        message = stub(:attr => {'RFC822' => 'a message'})
+        uid = 123
         
-        mailbox.deliver(message)
+        mailbox.deliver?(uid)
 
-        redis.should have_received(:deliver?).with(message)
+        redis.should have_received(:deliver?).with(uid)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'bundler/setup'
 require 'rspec'
 require 'mocha/api'
 require 'bourne'
+require 'fakeredis/rspec'
 
 require File.expand_path('../../lib/mail_room', __FILE__)
 


### PR DESCRIPTION
Fixes #46.

First attempt at solving this much talked about issue :)

## Example config

```yaml
:mailboxes:
  -
    # Yada yada, stuff we know

    :arbitration_method: redis
    :arbitration_options:
      :redis_url: unix:/path/to/redis/redis.socket
      :namespace: mail_room
```

## Todo
- [x] Specs
- [ ] Documentation in readme

cc @tpitale @jacobvosmaer @cristianbica