### PR TITLE
Evaluate ERB in config file.

### DIFF
--- a/lib/mail_room/configuration.rb
+++ b/lib/mail_room/configuration.rb
@@ -1,3 +1,5 @@
+require "erb"
+
 module MailRoom
   # Wraps configuration for a set of individual mailboxes with global config
   # @author Tony Pitale
@@ -11,7 +13,7 @@ module MailRoom
 
       if options.has_key?(:config_path)
         begin
-          config_file = YAML.load_file(options[:config_path])
+          config_file = YAML.load(ERB.new(File.read(options[:config_path])).result)
 
           set_mailboxes(config_file[:mailboxes])
         rescue => e


### PR DESCRIPTION
This allows users to put their credentials etc in environment variables:

```yaml
mailboxes:
  -
    :email: "user1@gmail.com"
    :password: <%= ENV["MAILBOX_PASSWORD"] %>
```

It also allows us (GitLab) to keep users from having to edit `mail_room.yml` directly to set up Reply by email, since there's a lot of stuff in there that they shouldn't touch that is always the same for GitLab:

```yaml
# Postfix mail server
:mailboxes:
  -
    # IMAP server host
    :host: "gitlab.example.com"
    # IMAP server port
    :port: 143
    # Whether the IMAP server uses SSL
    :ssl: false
    # Whether the IMAP server uses StartTLS
    :start_tls: false
    # Email account username. Usually the full email address.
    :email: "incoming"
    # Email account password
    :password: "[REDACTED]"
    # The name of the mailbox where incoming mail will end up. Usually "inbox".
    :name: "inbox"
    # Always "sidekiq".
    :delivery_method: sidekiq
    # Always true.
    :delete_after_delivery: true
    :delivery_options:
      # The URL to the Redis server used by Sidekiq. Should match the URL in config/resque.yml.
      :redis_url: redis://localhost:6379
      # Always "resque:gitlab".
      :namespace: resque:gitlab
      # Always "incoming_email".
      :queue: incoming_email
      # Always "EmailReceiverWorker"
      :worker: EmailReceiverWorker

    :arbitration_method: redis
    :arbitration_options:
      # The URL to the Redis server. Should match the URL in config/resque.yml.
      :redis_url: redis://localhost:6379
      # Always "mail_room:gitlab"
      :namespace: mail_room:gitlab

```

Our own config file would only need the `host`, `port`, `ssl`, `start_tls`, `username` and `password` fields. The Redis URL is already set in `config/resque.yml`, so we can remove the duplication and just read it from there.