### PR TITLE
Postgresql-based advisory lock arbitration method

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ I suggest running with either upstart or init.d. Check out this wiki page for so
 
 ## Arbitration ##
 
-When running multiple instances of MailRoom against a single mailbox, to try to prevent delivery of the same message multiple times, we can configure Arbitration using Redis.
+When running multiple instances of MailRoom against a single mailbox, to try to prevent delivery of the same message multiple times, we can configure Arbitration using:
+
+### Redis ###
 
 ```yaml
 :mailboxes:
@@ -233,6 +235,31 @@ When running multiple instances of MailRoom against a single mailbox, to try to 
 
 **Note:** There are other scenarios for preventing duplication of messages at scale that _may_ be more appropriate in your particular setup. One such example is using multiple inboxes in reply-by-email situations. Another is to use labels and configure a different `SEARCH` command for each instance of MailRoom.
 
+### PostgreSQL ###
+
+```yaml
+:mailboxes:
+  -
+    :email: "user1@gmail.com"
+    :password: "password"
+    :name: "inbox"
+    :delivery_method: postback
+    :delivery_options:
+      :delivery_url: "http://localhost:3000/inbox"
+      :delivery_token: "abcdefg"
+     
+    :arbitration_method: postgresql
+    :arbitration_options:
+      # The server to connect with. Defaults to localhost
+      :host: 'your.database.domain.com'
+      # The server port. Defaults to 5432
+      :port: 5432
+      :database: 'your_database'
+      :username: 'your_database_user'
+      :password: 'some_secret_password'
+
+```
+
 ## Contributing ##
 
 1. Fork it
@@ -241,13 +268,3 @@ When running multiple instances of MailRoom against a single mailbox, to try to 
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
 6. If accepted, ask for commit rights
-
-## TODO ##
-
-1. specs, this is just a (working) proof of concept √
-2. finish code for POSTing to callback with auth √
-3. accept mailbox configuration for one account directly on the commandline; or ask for it
-4. add example rails endpoint, with auth examples
-5. add example configs for upstart/init.d √
-6. log to stdout √
-7. add a development mode that opens in letter_opener by ryanb √

--- a/lib/mail_room/arbitration.rb
+++ b/lib/mail_room/arbitration.rb
@@ -1,11 +1,13 @@
 module MailRoom
   module Arbitration
-    def [](name)
-      require_relative("./arbitration/#{name}")
+    def [](name = nil)
+      require_relative("./arbitration/#{name}") if name
 
       case name
       when "redis"
         Arbitration::Redis
+      when "postgresql"
+        Arbitration::PostgreSQL
       else
         Arbitration::Noop
       end

--- a/lib/mail_room/arbitration/postgresql.rb
+++ b/lib/mail_room/arbitration/postgresql.rb
@@ -1,0 +1,57 @@
+require 'pg'
+
+module MailRoom
+  module Arbitration
+    class PostgreSQL
+      Options = Struct.new(:host, :port, :database, :username, :password) do
+        def initialize(mailbox)
+          host = mailbox.arbitration_options.fetch(:host, "localhost")
+          port = mailbox.arbitration_options.fetch(:port, 5432)
+
+          database = mailbox.arbitration_options[:database]
+          username = mailbox.arbitration_options[:username]
+          password = mailbox.arbitration_options[:password]
+
+          super(host, port, database, username, password)
+        end
+      end
+
+      attr_reader :options, :connection
+
+      def initialize(options)
+        @options = options
+
+        # Retain the PG connection for the life
+        # of this mailbox/arbitrator so that locks
+        # are not released until the process dies.
+        #
+        # Hopefully, by that time, all other processes
+        # will have already read and passed over
+        # delivering the messages that this proccess
+        # has already delivered
+        @connection = PG.connect({
+          host: options.host,
+          port: options.port,
+          dbname: options.database,
+          user: options.username,
+          password: options.password
+        })
+      end
+
+      # Do we deliver this message?
+      # 
+      # @param uid [Integer] the unique id from mail
+      # @return Boolean
+      def deliver?(uid)
+        obtain_advisory_lock?(uid)
+      end
+
+      private
+
+      # @private
+      def obtain_advisory_lock?(uid)
+        connection.exec_params('SELECT pg_try_advisory_lock($1);', [uid]).getvalue(0,0) == 't'
+      end
+    end
+  end
+end

--- a/spec/lib/arbitration/postgresql_spec.rb
+++ b/spec/lib/arbitration/postgresql_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'mail_room/arbitration/postgresql'
+
+describe MailRoom::Arbitration::PostgreSQL do
+  let(:mailbox) { 
+    MailRoom::Mailbox.new(
+      arbitration_options: {
+        database: 'mail_room_test',
+        username: 'postgres',
+        password: 'password'
+      }
+    )
+  }
+  let(:options) { described_class::Options.new(mailbox) }
+  let(:connection) {stub}
+
+  before(:each) do
+    PG.stubs(:connect).returns(connection)
+  end
+
+  subject { described_class.new(options) }
+
+  it 'connects to postgresql' do
+    subject # call subject to run #initialize
+
+    expect(PG).to have_received(:connect).with({
+      host: 'localhost',
+      port: 5432,
+      dbname: 'mail_room_test',
+      user: 'postgres',
+      password: 'password'
+    })
+  end
+
+  it 'returns true if an advisory lock for the UID can be obtained' do
+    result = stub(:getvalue => 't')
+    connection.stubs(:exec_params).returns(result)
+
+    expect(subject.deliver?(88819328181)).to eq(true)
+
+    expect(connection).to have_received(:exec_params).with('SELECT pg_try_advisory_lock($1);', [88819328181])
+    expect(result).to have_received(:getvalue).with(0,0)
+  end
+
+  it 'returns true if an advisory lock for the UID can be obtained' do
+    result = stub(:getvalue => 'f')
+    connection.stubs(:exec_params).returns(result)
+
+    expect(subject.deliver?(88819328981)).to eq(false)
+
+    expect(connection).to have_received(:exec_params).with('SELECT pg_try_advisory_lock($1);', [88819328981])
+  end
+end


### PR DESCRIPTION
- (Attempt at) matching arbitration functionality from redis
- Rather than a 10 minute expiry, as in redis, locks are held for the lifetime of the connection (session), essentially the life of the process. This should prevent the vast majority of duplicate deliveries except (theoretically) when one mailbox process dies _very_ shortly after sending some deliveries. If that happens, another mailbox process _could_ be timed in such a way as to pick up some message UIDs that have already been delivered.
- pg_try_advisory_lock will return 't' or 'f', as long as the database is shared (a shared mutex, just like we do with redis)

Docs and (maybe) benchmarks to come.

/cc @DouweM in case you're interested
