### PR TITLE
Backport IDLE timeout from ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.0.0
   - 2.1.5
-  - 2.2.0
+  - 2.2.4
+  - 2.3.0
 script: bundle exec rspec spec
 sudo: false

--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ disabled, you can get the raw string of the email using `request.body.read`.
 I would recommend having the `mail` gem bundled and parse the email using
 `Mail.read_from_string(request.body.read)`.
 
+## idle_timeout ##
+
+By default, the IDLE command will wait for 29 minutes (in order to keep the server connection happy).
+If you'd prefer not to wait that long, you can pass `imap_timeout` in seconds for your mailbox configuration.
+
 ## Search Command ##
 
 This setting allows configuration of the IMAP search command sent to the server. This still defaults 'UNSEEN'. You may find that 'NEW' works better for you.

--- a/lib/mail_room.rb
+++ b/lib/mail_room.rb
@@ -6,6 +6,7 @@ module MailRoom
 end
 
 require "mail_room/version"
+require "mail_room/backports/imap"
 require "mail_room/configuration"
 require "mail_room/mailbox"
 require "mail_room/mailbox_watcher"

--- a/lib/mail_room/backports/imap.rb
+++ b/lib/mail_room/backports/imap.rb
@@ -1,0 +1,33 @@
+module MailRoom
+  class IMAP < Net::IMAP
+    # Backported 2.3.0 version of net/imap idle command to support timeout
+    def idle(timeout = nil, &response_handler)
+      raise LocalJumpError, "no block given" unless response_handler
+
+      response = nil
+
+      synchronize do
+        tag = Thread.current[:net_imap_tag] = generate_tag
+        put_string("#{tag} IDLE#{CRLF}")
+
+        begin
+          add_response_handler(response_handler)
+          @idle_done_cond = new_cond
+          @idle_done_cond.wait(timeout)
+          @idle_done_cond = nil
+          if @receiver_thread_terminating
+            raise Net::IMAP::Error, "connection closed"
+          end
+        ensure
+          unless @receiver_thread_terminating
+            remove_response_handler(response_handler)
+            put_string("DONE#{CRLF}")
+            response = get_tagged_response(tag, "IDLE")
+          end
+        end
+      end
+
+      return response
+    end
+  end
+end

--- a/spec/lib/mailbox_watcher_spec.rb
+++ b/spec/lib/mailbox_watcher_spec.rb
@@ -25,14 +25,12 @@ describe MailRoom::MailboxWatcher do
   end
 
   describe '#imap' do
-    let(:mailbox) {MailRoom::Mailbox.new}
-
     it 'builds a new Net::IMAP object' do
-      Net::IMAP.stubs(:new).returns('imap')
+      MailRoom::IMAP.stubs(:new).returns('imap')
 
       MailRoom::MailboxWatcher.new(mailbox).imap.should eq('imap')
 
-      Net::IMAP.should have_received(:new).with('imap.gmail.com', :port => 993, :ssl => true)
+      MailRoom::IMAP.should have_received(:new).with('imap.gmail.com', :port => 993, :ssl => true)
     end
   end
 
@@ -40,7 +38,7 @@ describe MailRoom::MailboxWatcher do
     let(:imap) {stub(:login => true, :select => true)}
 
     let(:mailbox) {
-      MailRoom::Mailbox.new(:email => 'user1@gmail.com', :password => 'password', :name => 'inbox', )
+      MailRoom::Mailbox.new(:email => 'user1@gmail.com', :password => 'password', :name => 'inbox')
     }
 
     let(:watcher) {
@@ -74,7 +72,7 @@ describe MailRoom::MailboxWatcher do
 
   describe '#idle' do
     let(:imap) {stub}
-    let(:watcher) {MailRoom::MailboxWatcher.new(nil)}
+    let(:watcher) {MailRoom::MailboxWatcher.new(mailbox)}
 
     before :each do
       watcher.stubs(:imap).returns(imap)


### PR DESCRIPTION
This sucks, but not everyone can upgrade to ruby 2.3 at this time.

* subclass Net::IMAP
* copy #idle method
* define 29 minute idle timeout on wait condition
* remove the timeout thread (passing timeout to idle supplants this functionality)
* configuration of idle_timeout in the mailbox

Relates to #61 