### PR TITLE
Don't override original idle method for Net::IMAP

### DIFF
--- a/lib/mail_room/backports/imap.rb
+++ b/lib/mail_room/backports/imap.rb
@@ -28,6 +28,6 @@ module MailRoom
       end
 
       return response
-    end
+    end unless public_method_defined?(:idle)
   end
 end


### PR DESCRIPTION
So that we take advantage of future official code

Thanks!