### PR TITLE
Reset handler otherwise handler would be using the old imap

### DIFF
--- a/lib/mail_room/mailbox_watcher.rb
+++ b/lib/mail_room/mailbox_watcher.rb
@@ -74,6 +74,7 @@ module MailRoom
     # reset imap state
     def reset
       @imap = nil
+      @handler = nil
       @logged_in = false
       @idling = false
     end


### PR DESCRIPTION
I just realized that this is probably the real fix for https://github.com/tpitale/mail_room/issues/61
That `handler` is always holding the old `Net::IMAP` instance!

Perhaps we should have a test for this.

Related discussion: https://gitlab.com/gitlab-org/gitlab-ce/issues/13357#note_12456803