### PR TITLE
Fix possible race condition in mailbox_watcher.rb quit method

### DIFF
--- a/lib/mail_room/mailbox_watcher.rb
+++ b/lib/mail_room/mailbox_watcher.rb
@@ -47,7 +47,9 @@ module MailRoom
         @connection = nil
       end
 
-      watching_thread.join
+      if self.watching_thread
+        self.watching_thread.join
+      end
     end
 
     private


### PR DESCRIPTION
Fixes undefined method `join' for nil:NilClass in quit method. Issue #77.

Exception:
2016-07-26_08:31:54.08717 /opt/gitlab/embedded/service/gem/ruby/2.1.0/gems/mail_room-0.8.0/lib/mail_room/mailbox_watcher.rb:50:in `quit': undefined method `join' for nil:NilClass (NoMethodError)
2016-07-26_08:31:54.08721       from /opt/gitlab/embedded/service/gem/ruby/2.1.0/gems/mail_room-0.8.0/lib/mail_room/coordinator.rb:30:in `each'
2016-07-26_08:31:54.08721       from /opt/gitlab/embedded/service/gem/ruby/2.1.0/gems/mail_room-0.8.0/lib/mail_room/coordinator.rb:30:in `quit'
2016-07-26_08:31:54.08722       from /opt/gitlab/embedded/service/gem/ruby/2.1.0/gems/mail_room-0.8.0/lib/mail_room/coordinator.rb:25:in `ensure in run'
2016-07-26_08:31:54.08722       from /opt/gitlab/embedded/service/gem/ruby/2.1.0/gems/mail_room-0.8.0/lib/mail_room/coordinator.rb:25:in `run'
2016-07-26_08:31:54.08722       from /opt/gitlab/embedded/service/gem/ruby/2.1.0/gems/mail_room-0.8.0/lib/mail_room/cli.rb:52:in `start'