### PR TITLE
Sentinel support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,31 @@
+# Cache gems in between builds
+
+.test-template: &test
+  cache:
+    paths:
+      - vendor/ruby
+  script:
+  - bundle exec rspec spec
+  before_script:
+    - apt update && apt install -y libicu-dev
+    - ruby -v                                   # Print out ruby version for debugging
+    # Uncomment next line if your rails app needs a JS runtime:
+    # - apt-get update -q && apt-get install nodejs -yqq
+    - gem install bundler  --no-ri --no-rdoc    # Bundler is not installed with the image
+    - bundle install -j $(nproc) --path vendor  # Install dependencies into ./vendor/ruby
+
+rspec-2.0:
+  image: "ruby:2.0"
+  <<: *test
+
+rspec-2.1:
+  image: "ruby:2.1"
+  <<: *test
+
+rspec-2.2:
+  image: "ruby:2.2"
+  <<: *test
+
+rspec-2.3:
+  image: "ruby:2.3"
+  <<: *test

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
     :delivery_options:
       :delivery_url: "http://localhost:3000/inbox"
       :delivery_token: "abcdefg"
-    
+
   -
     :email: "user2@gmail.com"
     :password: "password"
@@ -76,6 +76,20 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
     :delivery_options:
       :redis_url: redis://localhost:6379
       :worker: EmailReceiverWorker
+  -
+    :email: "user6@gmail.com"
+    :password: "password"
+    :name: "inbox"
+    :delivery_method: sidekiq
+    :delivery_options:
+      # When pointing to sentinel, follow this sintax for redis URLs:
+      # redis://:<password>@<master-name>/
+      :redis_url: redis://:password@my-redis-sentinel/
+      :sentinels:
+        -
+          :host: 127.0.0.1
+          :port: 26379
+      :worker: EmailReceiverWorker
 ```
 
 ## delivery_method ##
@@ -86,12 +100,12 @@ Requires `faraday` gem be installed.
 
 *NOTE:* If you're using Ruby `>= 2.0`, you'll need to use Faraday from `>= 0.8.9`. Versions before this seem to have some weird behavior with `mail_room`.
 
-The default delivery method, requires `delivery_url` and `delivery_token` in 
+The default delivery method, requires `delivery_url` and `delivery_token` in
 configuration.
 
-As the postback is essentially using your app as if it were an API endpoint, 
-you may need to disable forgery protection as you would with a JSON API. In 
-our case, the postback is plaintext, but the protection will still need to be 
+As the postback is essentially using your app as if it were an API endpoint,
+you may need to disable forgery protection as you would with a JSON API. In
+our case, the postback is plaintext, but the protection will still need to be
 disabled.
 
 ### sidekiq ###
@@ -105,6 +119,8 @@ Configured with `:delivery_method: sidekiq`.
 Delivery options:
 - **redis_url**: The Redis server to connect with. Use the same Redis URL that's used to configure Sidekiq.
   Required, defaults to `redis://localhost:6379`.
+- **sentinels**: A list of sentinels servers used to provide HA to Redis. (see [Sentinel Support](#sentinel-support))
+  Optional.
 - **namespace**: The Redis namespace Sidekiq works under. Use the same Redis namespace that's used to configure Sidekiq.
   Optional.
 - **queue**: The Sidekiq queue the job is pushed onto. Make sure Sidekiq actually reads off this queue.

--- a/README.md
+++ b/README.md
@@ -224,19 +224,56 @@ When running multiple instances of MailRoom against a single mailbox, to try to 
     :delivery_options:
       :delivery_url: "http://localhost:3000/inbox"
       :delivery_token: "abcdefg"
-     
+
     :arbitration_method: redis
     :arbitration_options:
       # The Redis server to connect with. Defaults to redis://localhost:6379.
       :redis_url: redis://redis.example.com:6379
-      # The Redis namespace to house the Redis keys under. Optional. 
+      # The Redis namespace to house the Redis keys under. Optional.
       :namespace: mail_room
+  -
+    :email: "user2@gmail.com"
+    :password: "password"
+    :name: "inbox"
+    :delivery_method: postback
+    :delivery_options:
+      :delivery_url: "http://localhost:3000/inbox"
+      :delivery_token: "abcdefg"
 
+    :arbitration_method: redis
+    :arbitration_options:
+      # When pointing to sentinel, follow this sintax for redis URLs:
+      # redis://:<password>@<master-name>/
+      :redis_url: redis://:password@my-redis-sentinel/
+      :sentinels:
+        -
+          :host: 127.0.0.1
+          :port: 26379
+      # The Redis namespace to house the Redis keys under. Optional.
+      :namespace: mail_room
 ```
 
 **Note:** This will likely never be a _perfect_ system for preventing multiple deliveries of the same message, so I would advise checking the unique `message_id` if you are running in this situation.
 
 **Note:** There are other scenarios for preventing duplication of messages at scale that _may_ be more appropriate in your particular setup. One such example is using multiple inboxes in reply-by-email situations. Another is to use labels and configure a different `SEARCH` command for each instance of MailRoom.
+
+## Sentinel Support
+
+Redis Sentinel provides high availability for Redis. Please read their [documentation](http://redis.io/topics/sentinel)
+first, before enabling it with mail_room.
+
+To connect to a Sentinel, you need to setup authentication to both sentinels and redis daemons first, and make sure
+both are binding to a reachable IP address.
+
+In mail_room, when you are connecting to a Sentinel, you have to inform the `master-name` and the `password` through
+`redis_url` param, following this syntax:
+
+```
+redis://:<password>@<master-name>/
+```
+
+You also have to inform at least one pair of `host` and `port` for a sentinel in your cluster.
+To have a minimum reliable setup, you need at least `3` sentinel nodes and `3` redis servers (1 master, 2 slaves).
 
 ## Contributing ##
 

--- a/lib/mail_room/arbitration/redis.rb
+++ b/lib/mail_room/arbitration/redis.rb
@@ -46,11 +46,10 @@ module MailRoom
       def redis
         @redis ||= begin
           sentinels = options.sentinels
-          if sentinels
-            redis = ::Redis.new(url: options.redis_url, sentinels: sentinels)
-          else
-            redis = ::Redis.new(url: options.redis_url)
-          end
+          redis_options = { url: options.redis_url }
+          redis_options[:sentinels] = sentinels if sentinels
+
+          redis = ::Redis.new(redis_options)
 
           namespace = options.namespace
           if namespace

--- a/lib/mail_room/delivery/sidekiq.rb
+++ b/lib/mail_room/delivery/sidekiq.rb
@@ -45,7 +45,7 @@ module MailRoom
         redis_options = { url: options.redis_url }
         redis_options[:sentinels] = sentinels if sentinels
 
-        redis = ::Redis.new(redis_options)
+        client = ::Redis.new(redis_options)
 
         namespace = options.namespace
         if namespace

--- a/lib/mail_room/delivery/sidekiq.rb
+++ b/lib/mail_room/delivery/sidekiq.rb
@@ -8,14 +8,15 @@ module MailRoom
     # Sidekiq Delivery method
     # @author Douwe Maan
     class Sidekiq
-      Options = Struct.new(:redis_url, :namespace, :queue, :worker) do
+      Options = Struct.new(:redis_url, :namespace, :sentinels, :queue, :worker) do
         def initialize(mailbox)
           redis_url = mailbox.delivery_options[:redis_url] || "redis://localhost:6379"
           namespace = mailbox.delivery_options[:namespace]
+          sentinels = mailbox.delivery_options[:sentinels]
           queue     = mailbox.delivery_options[:queue] || "default"
           worker    = mailbox.delivery_options[:worker]
 
-          super(redis_url, namespace, queue, worker)
+          super(redis_url, namespace, sentinels, queue, worker)
         end
       end
 
@@ -40,7 +41,12 @@ module MailRoom
       private
 
       def client
-        client = Redis.new(url: options.redis_url)
+        sentinels = options.sentinels
+        if sentinels
+          client = Redis.new(url: options.redis_url, sentinels: sentinels)
+        else
+          client = Redis.new(url: options.redis_url)
+        end
 
         namespace = options.namespace
         if namespace

--- a/lib/mail_room/delivery/sidekiq.rb
+++ b/lib/mail_room/delivery/sidekiq.rb
@@ -42,11 +42,10 @@ module MailRoom
 
       def client
         sentinels = options.sentinels
-        if sentinels
-          client = Redis.new(url: options.redis_url, sentinels: sentinels)
-        else
-          client = Redis.new(url: options.redis_url)
-        end
+        redis_options = { url: options.redis_url }
+        redis_options[:sentinels] = sentinels if sentinels
+
+        redis = ::Redis.new(redis_options)
 
         namespace = options.namespace
         if namespace

--- a/spec/lib/arbitration/redis_spec.rb
+++ b/spec/lib/arbitration/redis_spec.rb
@@ -104,7 +104,7 @@ describe MailRoom::Arbitration::Redis do
 
     context 'when sentinel is present' do
       let(:redis_url) { 'redis://:mypassword@sentinel-master:6379' }
-      let(:sentinels) { [host: '10.0.0.1', port: '26379'] }
+      let(:sentinels) { [{ host: '10.0.0.1', port: '26379' }] }
       let(:mailbox) {
         MailRoom::Mailbox.new(
           arbitration_options: {

--- a/spec/lib/arbitration/redis_spec.rb
+++ b/spec/lib/arbitration/redis_spec.rb
@@ -103,10 +103,12 @@ describe MailRoom::Arbitration::Redis do
     end
 
     context 'when sentinel is present' do
+      let(:redis_url) { 'redis://:mypassword@sentinel-master:6379' }
       let(:sentinels) { [host: '10.0.0.1', port: '26379'] }
       let(:mailbox) {
         MailRoom::Mailbox.new(
           arbitration_options: {
+            redis_url: redis_url,
             sentinels: sentinels
           }
         )
@@ -116,6 +118,8 @@ describe MailRoom::Arbitration::Redis do
 
       it 'client has same specified sentinel params' do
         expect(redis.client.instance_variable_get(:@connector)).to be_a Redis::Client::Connector::Sentinel
+        expect(redis.client.options[:host]).to eq('sentinel-master')
+        expect(redis.client.options[:password]).to eq('mypassword')
         expect(redis.client.options[:sentinels]).to eq(sentinels)
       end
     end

--- a/spec/lib/delivery/sidekiq_spec.rb
+++ b/spec/lib/delivery/sidekiq_spec.rb
@@ -50,6 +50,7 @@ describe MailRoom::Delivery::Sidekiq do
     end
 
     context 'when sentinel is specified' do
+      let(:redis_url) { 'redis://:mypassword@sentinel-master:6379' }
       let(:sentinels) { [host: '10.0.0.1', port: '26379'] }
       let(:mailbox) {
         MailRoom::Mailbox.new(
@@ -65,6 +66,8 @@ describe MailRoom::Delivery::Sidekiq do
 
       it 'client has same specified sentinel params' do
         expect(redis.client.instance_variable_get(:@connector)).to be_a Redis::Client::Connector::Sentinel
+        expect(redis.client.options[:host]).to eq('sentinel-master')
+        expect(redis.client.options[:password]).to eq('mypassword')
         expect(redis.client.options[:sentinels]).to eq(sentinels)
       end
     end

--- a/spec/lib/delivery/sidekiq_spec.rb
+++ b/spec/lib/delivery/sidekiq_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'mail_room/delivery/sidekiq'
+
+describe MailRoom::Delivery::Sidekiq do
+  subject { described_class.new(options) }
+  let(:redis) { subject.send(:client) }
+  let(:options) { MailRoom::Delivery::Sidekiq::Options.new(mailbox) }
+
+  describe '#options' do
+    let(:redis_url) { 'redis://redis.example.com' }
+
+    context 'when only redis_url is specified' do
+      let(:mailbox) {
+        MailRoom::Mailbox.new(
+          delivery_method: :sidekiq,
+          delivery_options: {
+            redis_url: redis_url
+          }
+        )
+      }
+
+      it 'client has same specified redis_url' do
+        expect(redis.options[:url]).to eq(redis_url)
+      end
+
+      it 'client is a instance of RedisNamespace class' do
+        expect(redis).to be_a ::Redis
+      end
+    end
+
+    context 'when namespace is specified' do
+      let(:namespace) { 'sidekiq_mailman' }
+      let(:mailbox) {
+        MailRoom::Mailbox.new(
+          delivery_method: :sidekiq,
+          delivery_options: {
+            redis_url: redis_url,
+            namespace: namespace
+          }
+        )
+      }
+
+      it 'client has same specified namespace' do
+        expect(redis.namespace).to eq(namespace)
+      end
+
+      it 'client is a instance of RedisNamespace class' do
+        expect(redis).to be_a ::Redis::Namespace
+      end
+    end
+
+    context 'when sentinel is specified' do
+      let(:sentinels) { [host: '10.0.0.1', port: '26379'] }
+      let(:mailbox) {
+        MailRoom::Mailbox.new(
+          delivery_method: :sidekiq,
+          delivery_options: {
+            redis_url: redis_url,
+            sentinels: sentinels
+          }
+        )
+      }
+
+      before { ::Redis::Client::Connector::Sentinel.any_instance.stubs(:resolve).returns(sentinels) }
+
+      it 'client has same specified sentinel params' do
+        expect(redis.client.instance_variable_get(:@connector)).to be_a Redis::Client::Connector::Sentinel
+        expect(redis.client.options[:sentinels]).to eq(sentinels)
+      end
+    end
+
+  end
+end

--- a/spec/lib/delivery/sidekiq_spec.rb
+++ b/spec/lib/delivery/sidekiq_spec.rb
@@ -51,7 +51,7 @@ describe MailRoom::Delivery::Sidekiq do
 
     context 'when sentinel is specified' do
       let(:redis_url) { 'redis://:mypassword@sentinel-master:6379' }
-      let(:sentinels) { [host: '10.0.0.1', port: '26379'] }
+      let(:sentinels) { [{ host: '10.0.0.1', port: '26379' }] }
       let(:mailbox) {
         MailRoom::Mailbox.new(
           delivery_method: :sidekiq,


### PR DESCRIPTION
Sentinel with the ruby client is a little tricky to get right, because they use a special convention in "Redis URL" to pass additional params.

When you have sentinel, it always handle the first connection your client will make to, and it redirects your to a working "master".

For a production setup, you need at least 3 independent machines, each one running redis and sentinel. One of these machines will have a master redis, the others will have slave redis.

For sake of testing, you can do 1 machine with 1 sentinel and 1 master and 1 slave redis running in different ports.

Here is a minimal `sentinel.conf` file:

```
bind 0.0.0.0
port 26379
sentinel monitor myredis 127.0.0.1 6379 1
sentinel down-after-milliseconds myredis 10000
sentinel auth-pass myredis "mypassword"
``` 

`myredis` is the `<master-name>` as stated in sentinel.conf documentation: http://download.redis.io/redis-stable/sentinel.conf

With that setup, here is how you connect to sentinel with Redis client (in ruby):

```ruby
client = ::Redis.new(url: 'redis://:mypassword@myredis/', sentinels: [host: '127.0.0.1', port: 26379]
client.info # to make sure it worked, check output.
```

**What can go wrong?**
This is the most common error: `Redis::CannotConnectError: No sentinels available.` and the most frustating one to debug.

It can mean literally anything. Your password is wrong, you are pointing to an unreachable address, invalid port, you typed the wrong "master-name" in the url, etc.

----

With this PR you can make MailRoom use Sentinel to connect to Redis for both Sidekiq and Arbitration

Here is a sample config.yml:

```yaml
---
:mailboxes:
  -
    :email: "user1@domain.tld"
    :password: "mypassword"
    :name: "inbox"
    :search_command: 'NEW'
    :host: 127.0.0.1
    :port: 1430
    :ssl: false
    :delivery_method: sidekiq
    :delivery_options:
      :redis_url: "redis://:mypassword@myredis:6379"
      :sentinels:
        -
          :host: 127.0.0.1
          :port: 26379
    :arbitration_method: redis
    :arbitration_options:
      :redis_url: "redis://:mypassword@myredis:6379"
      :sentinels:
        -
          :host: 127.0.0.1
          :port: 26379
```

fixes #55
