### PR TITLE
Set config file path in ERB so __FILE__ can be used

### DIFF
--- a/lib/mail_room/configuration.rb
+++ b/lib/mail_room/configuration.rb
@@ -13,7 +13,9 @@ module MailRoom
 
       if options.has_key?(:config_path)
         begin
-          config_file = YAML.load(ERB.new(File.read(options[:config_path])).result)
+          erb = ERB.new(File.read(options[:config_path]))
+          erb.filename = options[:config_path]
+          config_file = YAML.load(erb.result)
 
           set_mailboxes(config_file[:mailboxes])
         rescue => e
@@ -23,7 +25,7 @@ module MailRoom
     end
 
     # Builds individual mailboxes from YAML configuration
-    # 
+    #
     # @param mailboxes_config
     def set_mailboxes(mailboxes_config)
       mailboxes_config.each do |attributes|


### PR DESCRIPTION
This is a very minimal change, and has no side-effects.

A little context on why this is necessary to me:

https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/mail_room.yml#L6

We have extracted a lot of logic from our `.yml` into a separated class. 
The ERB provides almost all ruby features, but as it's using `eval` and it has no clue from where the content is coming, there is no `root path`, so require and require_relative doesn't work as we expect (you need to be in the specific root directory when you call the mail_room, otherwise it doesn't work).

With omnibus we bundle every dependency in a specific and different directory hierarchy, that handles that file's require unusable, so we have to overwrite it with a full path to the ruby files in the requires.

We can hint ERB (with the `erb.filename`) and let it knows where the file is. This allow us to use `__FILE__` inside the `.yml` and solve the require part correctly.

cc @DouweM @godfat @tpitale 

Additional context: https://gitlab.com/gitlab-org/omnibus-gitlab/issues/1363