### PR TITLE
Redis arbitration to use set with nx + ex, to avoid locking issue.

### DIFF
--- a/spec/lib/arbitration/redis_spec.rb
+++ b/spec/lib/arbitration/redis_spec.rb
@@ -41,14 +41,13 @@ describe MailRoom::Arbitration::Redis do
       end
 
       it "returns false" do
-        # While we expect false normally, fakeredis converts false into 0 (see command_executor.rb)
-        # so this test has to expect 0.
-        expect(subject.deliver?(123, 2)).to eq(0)
+        # Fails locally because fakeredis returns 0, not false
+        expect(subject.deliver?(123, 2)).to be_falsey
       end
 
       it "after expiration returns true" do
-        # See above; return value is zero under fakeredis
-        expect(subject.deliver?(123, 2)).to eq(0)
+        # Fails locally because fakeredis returns 0, not false
+        expect(subject.deliver?(123, 2)).to be_falsey
         sleep(client.ttl("delivered:123")+1)
         expect(subject.deliver?(123, 2)).to be_truthy
       end


### PR DESCRIPTION
Solves #84

There's a bit of ugly in the tests (fakeredis turns false into 0, for some presumably sensible reasons).

Also had to make expiration be a param (with a default) on deliver? so we can test the expiry behavior works; hopefully that's ok.