### PR TITLE
Log configuration moved around a bit before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
     :password: "password"
     :name: "inbox"
     :search_command: 'NEW'
+    :logger:
+      :log_path: /path/to/logfile/for/mailroom
     :delivery_options:
       :delivery_url: "http://localhost:3000/inbox"
       :delivery_token: "abcdefg"
@@ -185,7 +187,7 @@ end
 
 Configured with `:delivery_method: logger`.
 
-If `:log_path:` is not provided, defaults to `STDOUT`
+If the `:log_path:` delivery option is not provided, defaults to `STDOUT`
 
 ### noop ###
 
@@ -319,6 +321,12 @@ redis://:<password>@<master-name>/
 
 You also have to inform at least one pair of `host` and `port` for a sentinel in your cluster.
 To have a minimum reliable setup, you need at least `3` sentinel nodes and `3` redis servers (1 master, 2 slaves).
+
+## Logging ##
+
+MailRoom will output JSON-formatted logs to give some observability into its operations.
+
+Simply configure a `log_path` for the `logger` on any of your mailboxes. By default, nothing will be logged.
 
 ## Contributing ##
 

--- a/lib/mail_room/delivery/postback.rb
+++ b/lib/mail_room/delivery/postback.rb
@@ -62,7 +62,7 @@ module MailRoom
           # request.headers['Content-Type'] = 'text/plain'
         end
 
-        @delivery_options.logger.info({ delivery_method: 'Postback', action: 'message pushed', url: @delivery_options.delivery_url })
+        @delivery_options.logger.info({ delivery_method: 'Postback', action: 'message pushed', url: @delivery_options.url })
         true
       end
     end

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -24,7 +24,7 @@ module MailRoom
     :delivery_options,
     :arbitration_method,
     :arbitration_options,
-    :structured_logger_file_name,
+    :logger
   ]
 
   ConfigurationError = Class.new(RuntimeError)
@@ -54,7 +54,8 @@ module MailRoom
       :expunge_deleted => false,
       :delivery_options => {},
       :arbitration_method => 'noop',
-      :arbitration_options => {}
+      :arbitration_options => {},
+      :logger => {}
     }
 
     # Store the configuration and require the appropriate delivery method
@@ -66,7 +67,14 @@ module MailRoom
     end
 
     def logger
-      @logger ||= MailRoom::Logger::Structured.new(structured_logger_file_name)
+      @logger ||=
+        case self[:logger]
+          when Logger
+            self[:logger]
+          else
+            self[:logger] ||= {}
+            MailRoom::Logger::Structured.new(self[:logger][:log_path])
+        end
     end
 
     def delivery_klass

--- a/spec/fixtures/test_config.yml
+++ b/spec/fixtures/test_config.yml
@@ -6,7 +6,8 @@
     :name: "inbox"
     :delivery_url: "http://localhost:3000/inbox"
     :delivery_token: "abcdefg"
-    :structured_logger_file_name: "logfile.log"
+    :logger:
+      :log_path: "logfile.log"
   -
     :email: "user2@gmail.com"
     :password: "password"

--- a/spec/lib/mailbox_spec.rb
+++ b/spec/lib/mailbox_spec.rb
@@ -102,7 +102,7 @@ describe MailRoom::Mailbox do
 
     context 'structured logger setup' do
       it 'sets up the logger correctly and does not error' do
-        mailbox = build_mailbox({ name: "magic mailbox", structured_logger_file_name: '/dev/null' })
+        mailbox = build_mailbox({ name: "magic mailbox", logger: { log_path: '/dev/null' } })
 
         expect{ mailbox.logger.info(message: "asdf") }.not_to raise_error
       end


### PR DESCRIPTION
@cablett What do you think of this? It will later allow us to have options for the type of logging to be done, defaulting to `json` structured (our only option right now). It will also later allow anyone using `mail_room` as a library to pass their own `Logger`.