### PR TITLE
Update gitlab-ci to reflect new ruby versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,27 +5,23 @@
     paths:
       - vendor/ruby
   script:
-  - bundle exec rspec spec
+    - bundle exec rspec spec
   before_script:
     - apt update && apt install -y libicu-dev
     - ruby -v                                   # Print out ruby version for debugging
     # Uncomment next line if your rails app needs a JS runtime:
     # - apt-get update -q && apt-get install nodejs -yqq
-    - gem install bundler  --no-ri --no-rdoc    # Bundler is not installed with the image
+    - gem install bundler  --no-document    # Bundler is not installed with the image
     - bundle install -j $(nproc) --path vendor  # Install dependencies into ./vendor/ruby
 
-rspec-2.0:
-  image: "ruby:2.0"
+rspec-2.5:
+  image: "ruby:2.5"
   <<: *test
 
-rspec-2.1:
-  image: "ruby:2.1"
+rspec-2.6:
+  image: "ruby:2.6"
   <<: *test
 
-rspec-2.2:
-  image: "ruby:2.2"
-  <<: *test
-
-rspec-2.3:
-  image: "ruby:2.3"
+rspec-2.7:
+  image: "ruby:2.7"
   <<: *test


### PR DESCRIPTION
Hi @tpitale ! Hope you and yours are safe and well.

I noticed the ruby versions, etc in the `gitlab-ci.yml` were out of date, so here's a change that will bring them more up to date 🙂 The version here works with the current GitLab CI engine as of this writing.

What do you think?