### PR TITLE
Modify crash handler

### DIFF
--- a/lib/mail_room/cli.rb
+++ b/lib/mail_room/cli.rb
@@ -55,7 +55,7 @@ module MailRoom
 
       coordinator.run
     rescue Exception => e # not just Errors, but includes lower-level Exceptions
-      CrashHandler.new(error: e, format: @options[:exit_error_format]).handle
+      CrashHandler.new.handle(e, @options[:exit_error_format])
       exit
     end
   end

--- a/lib/mail_room/crash_handler.rb
+++ b/lib/mail_room/crash_handler.rb
@@ -1,8 +1,7 @@
 
 module MailRoom
   class CrashHandler
-
-    SUPPORTED_FORMATS = %w[json plain]
+    SUPPORTED_FORMATS = %w[json none]
 
     def initialize(stream=STDOUT)
       @stream = stream

--- a/lib/mail_room/crash_handler.rb
+++ b/lib/mail_room/crash_handler.rb
@@ -2,18 +2,15 @@
 module MailRoom
   class CrashHandler
 
-    attr_reader :error, :format
+    SUPPORTED_FORMATS = %w[json plain]
 
-    SUPPORTED_FORMATS = %w[json none]
-
-    def initialize(error:, format:)
-      @error = error
-      @format = format
+    def initialize(stream=STDOUT)
+      @stream = stream
     end
 
-    def handle
+    def handle(error, format)
       if format == 'json'
-        puts json
+        @stream.puts json(error)
         return
       end
 
@@ -22,7 +19,7 @@ module MailRoom
 
     private
 
-    def json
+    def json(error)
       { time: Time.now, severity: :fatal, message: error.message, backtrace: error.backtrace }.to_json
     end
   end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -52,22 +52,21 @@ describe MailRoom::CLI do
     end
 
     context 'on error' do
-      let(:error_message) { "oh noes!" }
-      let(:error) { RuntimeError.new(error_message) }
-      let(:coordinator) { OpenStruct.new(run: true, quit: true) }
+      let(:error) { RuntimeError.new("oh noes!") }
+      let(:coordinator) { stub(run: true, quit: true) }
+      let(:crash_handler) { stub(handle: nil) }
 
       before do
         cli.instance_variable_set(:@options, {exit_error_format: error_format})
         coordinator.stubs(:run).raises(error)
+        MailRoom::CrashHandler.stubs(:new).returns(crash_handler)
       end
 
       context 'json format provided' do
         let(:error_format) { 'json' }
 
         it 'passes onto CrashHandler' do
-          handler = stub
-          handler.stubs(:handle)
-          MailRoom::CrashHandler.expects(:new).with({error: error, format: error_format}).returns(handler)
+          handler.expects(:handle).with(error, error_format)
 
           cli.start
         end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -66,7 +66,7 @@ describe MailRoom::CLI do
         let(:error_format) { 'json' }
 
         it 'passes onto CrashHandler' do
-          handler.expects(:handle).with(error, error_format)
+          crash_handler.expects(:handle).with(error, error_format)
 
           cli.start
         end


### PR DESCRIPTION
Hi @tpitale! 👋 

We're trying to get the `mail_room` gem to pass CI when hosted on gitlab.com.

It turned out GitLab's CI was giving a "false pass" and the tests were being aborted early by the `CrashHandler`. Thus, this PR modifies the `CrashHandler` a little so it still behaves identically, but means the tests genuinely pass.

What do you think?