### PR TITLE
Set plain format

### DIFF
--- a/lib/mail_room/crash_handler.rb
+++ b/lib/mail_room/crash_handler.rb
@@ -4,7 +4,7 @@ module MailRoom
 
     attr_reader :error, :format
 
-    SUPPORTED_FORMATS = %w[json none]
+    SUPPORTED_FORMATS = %w[json plain]
 
     def initialize(error:, format:)
       @error = error

--- a/spec/lib/crash_handler_spec.rb
+++ b/spec/lib/crash_handler_spec.rb
@@ -37,5 +37,13 @@ describe MailRoom::CrashHandler do
         expect{ subject.handle }.to raise_error(error.class, error_message)
       end
     end
+
+    context 'when given plain' do
+      let(:format) { "plain" }
+
+      it 'raises an error as designed (plain text, not structured)' do
+        expect{ subject.handle }.to raise_error(error.class, error_message)
+      end
+    end
   end
 end


### PR DESCRIPTION
I think `plain` rather than `none` might be better for crash log format, what do you think @tpitale?