### PR TITLE
Log bytesize

### DIFF
--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -106,7 +106,7 @@ module MailRoom
       body = message.attr['RFC822']
       return true unless body
 
-      logger.info({context: context, uid: message.attr['UID'], action: "sending to deliverer", deliverer: delivery.class.name, byte_size: message.attr['RFC822.SIZE']})
+      logger.info({context: context, uid: message.attr['UID'], action: "sending to deliverer", deliverer: delivery.class.name, byte_size: body.bytesize})
       delivery.deliver(body)
     end
 


### PR DESCRIPTION
We noticed that the size of the message wasn't being logged (it was `nil` for us) so this PR changes it to `body.size`.