### PR TITLE
Add redis_url to mailbox arbitration options

### DIFF
--- a/spec/lib/arbitration/redis_spec.rb
+++ b/spec/lib/arbitration/redis_spec.rb
@@ -5,7 +5,8 @@ describe MailRoom::Arbitration::Redis do
   let(:mailbox) {
     build_mailbox(
       arbitration_options: {
-        namespace: "mail_room"
+        namespace: "mail_room",
+        redis_url: ENV['REDIS_URL']
       }
     )
   }


### PR DESCRIPTION
One last small redis setup tweak, and this passes on GitLab CI 🚀 