### PR TITLE
Use `imap` method instead of instance variable

### DIFF
--- a/lib/mail_room/connection.rb
+++ b/lib/mail_room/connection.rb
@@ -27,7 +27,7 @@ module MailRoom
     # is the imap connection closed?
     # @return [Boolean]
     def disconnected?
-      @imap.disconnected?
+      imap.disconnected?
     end
 
     # is the connection ready to idle?
@@ -174,7 +174,7 @@ module MailRoom
     # @return [Array<Integer>] message ids
     def new_message_ids
       # uid_search still leaves messages UNSEEN
-      all_unread = @imap.uid_search(@mailbox.search_command)
+      all_unread = imap.uid_search(@mailbox.search_command)
 
       to_deliver = all_unread.select { |uid| @mailbox.deliver?(uid) }
       @mailbox.logger.info({ context: @mailbox.context, action: "Getting new messages", unread: {count: all_unread.count, ids: all_unread}, to_be_delivered: { count: to_deliver.count, ids: all_unread } })


### PR DESCRIPTION
Hi @tpitale ! Hope you're keeping well.

We ran into a problem with `mail_room` restarting and running into this error:

stack trace (snipped/modified slightly for clarity)
```
lib/mail_room/mailbox_watcher.rb:33 run> terminated with exception (report_on_exception is true):
lib/mail_room/connection.rb:177:in `new_message_ids': undefined method `uid_search' for nil:NilClass (NoMethodError)
lib/mail_room/connection.rb:166:in `new_messages'
lib/mail_room/connection.rb:137:in `process_mailbox'
lib/mail_room/connection.rb:51:in `wait'
lib/mail_room/mailbox_watcher.rb:35:in `block in run'
bundler: failed to load command: mail_room (bin/mail_room)
NoMethodError: undefined method `uid_search' for nil:NilClass
lib/mail_room/connection.rb:177:in `new_message_ids'
lib/mail_room/connection.rb:166:in `new_messages'
lib/mail_room/connection.rb:137:in `process_mailbox'
lib/mail_room/connection.rb:51:in `wait'
lib/mail_room/mailbox_watcher.rb:35:in `block in run'
Runit: waiting 5 seconds before restarting mail_room
```

I'm not sure why the instance variable `@imap` is used rather than the method, so I modified it in case this was not intentional.

We could also try `@imap&.uid_search` but I'm not sure that's any better 😅 

What do you think?