### PR TITLE
Add 'limit_max_unread' to avoid 'Error in IMAP command UID FETCH: Too long argument'

### DIFF
--- a/lib/mail_room/connection.rb
+++ b/lib/mail_room/connection.rb
@@ -50,7 +50,7 @@ module MailRoom
 
         process_mailbox
       rescue Net::IMAP::Error, IOError => e
-        @mailbox.logger.warn({ context: @mailbox.context, action: "Disconnected. Resetting...", error: e })
+        @mailbox.logger.warn({ context: @mailbox.context, action: "Disconnected. Resetting...", error: e.message })
         reset
         setup
       end

--- a/lib/mail_room/connection.rb
+++ b/lib/mail_room/connection.rb
@@ -176,11 +176,7 @@ module MailRoom
       # uid_search still leaves messages UNSEEN
       all_unread = imap.uid_search(@mailbox.search_command)
 
-      max_unread = @mailbox.limit_max_unread
-      if (max_unread > 0) && (all_unread.count > max_unread)
-        @mailbox.logger.warn({ context: @mailbox.context, action: "limit all_unread", count: all_unread.count, limit: max_unread})
-        all_unread = all_unread.slice(0, max_unread)
-      end
+      all_unread = all_unread.slice(0, @mailbox.limit_max_unread) unless @mailbox.limit_max_unread.nil? || @mailbox.limit_max_unread == 0
 
       to_deliver = all_unread.select { |uid| @mailbox.deliver?(uid) }
       @mailbox.logger.info({ context: @mailbox.context, action: "Getting new messages", unread: {count: all_unread.count, ids: all_unread}, to_be_delivered: { count: to_deliver.count, ids: to_deliver } })

--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -10,6 +10,7 @@ module MailRoom
     :port,
     :ssl,
     :start_tls,
+    :limit_max_unread, #to avoid 'Error in IMAP command UID FETCH: Too long argument'
     :idle_timeout,
     :search_command,
     :name,
@@ -50,6 +51,7 @@ module MailRoom
       :port => 993,
       :ssl => true,
       :start_tls => false,
+      :limit_max_unread => 0,
       :idle_timeout => IMAP_IDLE_TIMEOUT,
       :delete_after_delivery => false,
       :expunge_deleted => false,


### PR DESCRIPTION
* Add error message to 'disconnect exception'
* Fix logging the unread ids
* Add 'limit_max_unread' to avoid 'Error in IMAP command UID FETCH: Too long argument'