### PR TITLE
Update Net::IMAP to v0.2.1

### DIFF
--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency             "net-imap", ">= 0.2.1"
+
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.9"
   gem.add_development_dependency "mocha", "~> 1.11"


### PR DESCRIPTION
This potentially solves a deadlock issue in the previous version:
https://github.com/ruby/net-imap/pull/15

Ruby v2.7 ships with Net::IMAP v0.1.0. The diff is here:
https://github.com/ruby/net-imap/compare/v0.1.0..v0.2.1