### PR TITLE
Add Ruby 2.7 and 3.0 tests and drop Ruby 2.3 and 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.4
   - 2.5
   - 2.6
+  - 2.7
+  - 3.0
   - truffleruby
 services:
   - redis-server


### PR DESCRIPTION
Sicne net-imap is updated, we need to drop support for older Rubies.