### PR TITLE
Use ISO8601 timestamps for logging

### DIFF
--- a/lib/mail_room/crash_handler.rb
+++ b/lib/mail_room/crash_handler.rb
@@ -1,3 +1,4 @@
+require 'date'
 
 module MailRoom
   class CrashHandler
@@ -19,7 +20,7 @@ module MailRoom
     private
 
     def json(error)
-      { time: Time.now, severity: :fatal, message: error.message, backtrace: error.backtrace }.to_json
+      { time: DateTime.now.iso8601(3), severity: :fatal, message: error.message, backtrace: error.backtrace }.to_json
     end
   end
 end

--- a/lib/mail_room/logger/structured.rb
+++ b/lib/mail_room/logger/structured.rb
@@ -1,3 +1,4 @@
+require 'date'
 require 'logger'
 require 'json'
 
@@ -10,11 +11,24 @@ module MailRoom
 
         data = {}
         data[:severity] = severity
-        data[:time] = timestamp || Time.now.to_s
+        data[:time] = format_timestamp(timestamp || Time.now)
         # only accept a Hash
         data.merge!(message)
 
         data.to_json + "\n"
+      end
+
+      private
+
+      def format_timestamp(timestamp)
+        case timestamp
+        when Time
+          timestamp.to_datetime.iso8601(3).to_s
+        when DateTime
+          timestamp.iso8601(3).to_s
+        else
+          timestamp
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'simplecov'
 SimpleCov.start
 
 require 'bundler/setup'
+require 'date'
 
 require 'rspec'
 require 'mocha/api'


### PR DESCRIPTION
This makes it easier to parse messages for structured logging.