### PR TITLE
Fix warnings when loading net/protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.5
   - 2.6
   - 2.7
   - 3.0

--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -26,6 +26,9 @@ Gem::Specification.new do |gem|
 
   # for testing delivery methods
   gem.add_development_dependency "faraday"
+  # Ruby v3.0.0 made net-http a default gem. This dependency is needed to eliminate
+  # warnings when faraday is used. See https://github.com/lostisland/faraday-net_http/pull/5.
+  gem.add_development_dependency "net-http", "~> 0.1"
   gem.add_development_dependency "mail"
   gem.add_development_dependency "letter_opener"
   gem.add_development_dependency "redis", "~> 3.3.1"


### PR DESCRIPTION
As described in https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/, Ruby 3.0.0 promoted net-http and net-imap from stdlib. Adding net-http as a dependency avoids "already initialized constant errors" if net-imap and faraday are used.  See https://github.com/ruby/net-imap/issues/16#issuecomment-803086765 for
more details.
