### PR TITLE
Add Microsoft Graph API to retrieve mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If you're seeing the error `Please log in via your web browser: https://support.
 
 ### Microsoft Graph configuration
 
-To use the Microsoft Graph API instead of IMA to read e-mail, you will
+To use the Microsoft Graph API instead of IMAP to read e-mail, you will
 need to create an application in the Azure Active Directory. Follow the
 [Microsoft instructions](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-expose-web-apis).
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
       :tenant_id: 12345
       :client_id: ABCDE
       :client_secret: YOUR-SECRET-HERE
+      :poll_interval: 60
     :delivery_method: sidekiq
     :delivery_options:
       :redis_url: redis://localhost:6379
@@ -158,7 +159,11 @@ and fill in `inbox_options` with the values obtained above:
       :tenant_id: 12345
       :client_id: ABCDE
       :client_secret: YOUR-SECRET-HERE
+      :poll_interval: 60
 ```
+
+By default, MailRoom will poll for new messages every 60 seconds. `poll_interval` configures the number of
+seconds to poll. Setting the value to 0 or under will default to 60 seconds.
 
 ## delivery_method ##
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # mail_room #
 
-mail_room is a configuration based process that will idle on IMAP connections and execute a delivery method when a new message is received. Examples of delivery methods include:
+mail_room is a configuration based process that will listen for incoming
+e-mail and execute a delivery method when a new message is
+received. mail_room supports the following methods for receiving e-mail:
+
+* IMAP
+* [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/api/resources/mail-api-overview?view=graph-rest-1.0)
+
+Examples of delivery methods include:
 
 * POST to a delivery URL (Postback)
 * Queue a job to Sidekiq or Que for later processing (Sidekiq or Que)
@@ -94,10 +101,64 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
           :host: 127.0.0.1
           :port: 26379
       :worker: EmailReceiverWorker
+  -
+    :email: "user7@outlook365.com"
+    :password: "password"
+    :name: "inbox"
+    :inbox_method: microsoft_graph
+    :inbox_options:
+      :tenant_id: 12345
+      :client_id: ABCDE
+      :client_secret: YOUR-SECRET-HERE
+    :delivery_method: sidekiq
+    :delivery_options:
+      :redis_url: redis://localhost:6379
+      :worker: EmailReceiverWorker
 ```
 
 **Note:** If using `delete_after_delivery`, you also probably want to use
 `expunge_deleted` unless you really know what you're doing.
+
+## inbox_method
+
+By default, IMAP mode is assumed for reading a mailbox.
+
+### IMAP Server Configuration ##
+
+You can set per-mailbox configuration for the IMAP server's `host` (default: 'imap.gmail.com'), `port` (default: 993), `ssl` (default: true), and `start_tls` (default: false).
+
+If you want to set additional options for IMAP SSL you can pass a YAML hash to match [SSLContext#set_params](http://docs.ruby-lang.org/en/2.2.0/OpenSSL/SSL/SSLContext.html#method-i-set_params). If you set `verify_mode` to `:none` it'll replace with the appropriate constant.
+
+If you're seeing the error `Please log in via your web browser: https://support.google.com/mail/accounts/answer/78754 (Failure)`, you need to configure your Gmail account to allow less secure apps to access it: https://support.google.com/accounts/answer/6010255.
+
+### Microsoft Graph configuration
+
+To use the Microsoft Graph API instead of IMA to read e-mail, you will
+need to create an application in the Azure Active Directory. Follow the
+[Microsoft instructions](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-expose-web-apis).
+
+1. For MailRoom to work as a service account, this application add the
+application permission `Mail.ReadWrite` to read/write mail in *all*
+mailboxes. Delegated permissions for a specific user will NOT work.
+
+1. Be sure to grant admin consent for this application.
+
+1. [Create a client secret](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-app?tabs=dotnet#create-a-client-secret).
+
+1. To ensure this application can only read specific mailboxes, [follow these instructions](https://docs.microsoft.com/en-us/graph/auth-limit-mailbox-access).
+
+1. Obtain the client ID, client secret, and tenant ID for this application.
+
+In the MailRoom, configuration, set `inbox_method` to `microsoft_graph`,
+and fill in `inbox_options` with the values obtained above:
+
+```yaml
+    :inbox_method: microsoft_graph
+    :inbox_options:
+      :tenant_id: 12345
+      :client_id: ABCDE
+      :client_secret: YOUR-SECRET-HERE
+```
 
 ## delivery_method ##
 
@@ -248,14 +309,6 @@ If you'd prefer not to wait that long, you can pass `idle_timeout` in seconds fo
 ## Search Command ##
 
 This setting allows configuration of the IMAP search command sent to the server. This still defaults 'UNSEEN'. You may find that 'NEW' works better for you.
-
-## IMAP Server Configuration ##
-
-You can set per-mailbox configuration for the IMAP server's `host` (default: 'imap.gmail.com'), `port` (default: 993), `ssl` (default: true), and `start_tls` (default: false).
-
-If you want to set additional options for IMAP SSL you can pass a YAML hash to match [SSLContext#set_params](http://docs.ruby-lang.org/en/2.2.0/OpenSSL/SSL/SSLContext.html#method-i-set_params). If you set `verify_mode` to `:none` it'll replace with the appropriate constant.
-
-If you're seeing the error `Please log in via your web browser: https://support.google.com/mail/accounts/answer/78754 (Failure)`, you need to configure your Gmail account to allow less secure apps to access it: https://support.google.com/accounts/answer/6010255.
 
 ## Running in Production ##
 

--- a/lib/mail_room/mailbox_watcher.rb
+++ b/lib/mail_room/mailbox_watcher.rb
@@ -57,8 +57,14 @@ module MailRoom
     end
 
     private
+
     def connection
-      @connection ||= ::MailRoom::IMAP::Connection.new(@mailbox)
+      @connection ||=
+        if @mailbox.imap?
+          ::MailRoom::IMAP::Connection.new(@mailbox)
+        else
+          ::MailRoom::MicrosoftGraph::Connection.new(@mailbox)
+        end
     end
   end
 end

--- a/lib/mail_room/mailbox_watcher.rb
+++ b/lib/mail_room/mailbox_watcher.rb
@@ -60,10 +60,10 @@ module MailRoom
 
     def connection
       @connection ||=
-        if @mailbox.imap?
-          ::MailRoom::IMAP::Connection.new(@mailbox)
-        else
+        if @mailbox.microsoft_graph?
           ::MailRoom::MicrosoftGraph::Connection.new(@mailbox)
+        else
+          ::MailRoom::IMAP::Connection.new(@mailbox)
         end
     end
   end

--- a/lib/mail_room/microsoft_graph.rb
+++ b/lib/mail_room/microsoft_graph.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module MailRoom
+  module MicrosoftGraph
+    autoload :Connection, 'mail_room/microsoft_graph/connection'
+  end
+end

--- a/lib/mail_room/microsoft_graph/connection.rb
+++ b/lib/mail_room/microsoft_graph/connection.rb
@@ -8,6 +8,7 @@ module MailRoom
     class Connection < MailRoom::Connection
       SCOPE = 'https://graph.microsoft.com/.default'
       NEXT_PAGE_KEY = '@odata.nextLink'
+      DEFAULT_POLL_INTERVAL_S = 60
 
       TooManyRequestsError = Class.new(RuntimeError)
 
@@ -41,7 +42,7 @@ module MailRoom
       private
 
       def wait_for_new_messages
-        sleep 60
+        sleep poll_interval
       end
 
       def backoff
@@ -85,6 +86,18 @@ module MailRoom
 
       def client_secret
         inbox_options[:client_secret]
+      end
+
+      def poll_interval
+        @poll_interval ||= begin
+          interval = inbox_options[:poll_interval].to_i
+
+          if interval.positive?
+            interval
+          else
+            DEFAULT_POLL_INTERVAL_S
+          end
+        end
       end
 
       def process_mailbox

--- a/lib/mail_room/microsoft_graph/connection.rb
+++ b/lib/mail_room/microsoft_graph/connection.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'oauth2'
+
+module MailRoom
+  module MicrosoftGraph
+    class Connection < MailRoom::Connection
+      SCOPE = 'https://graph.microsoft.com/.default'
+      NEXT_PAGE_KEY = '@odata.nextLink'
+
+      TooManyRequestsError = Class.new(RuntimeError)
+
+      attr_accessor :token, :throttled_count
+
+      def initialize(mailbox)
+        super
+
+        reset
+        setup
+      end
+
+      def wait
+        process_mailbox
+
+        @throttled_count = 0
+        wait_for_new_messages
+      rescue TooManyRequestsError => e
+        @throttled_count += 1
+
+        @mailbox.logger.warn({ context: @mailbox.context, action: 'Too many requests, backing off...', backoff_s: backoff_secs, error: e.message, error_backtrace: e.backtrace })
+
+        backoff
+      rescue OAuth2::Error, IOError => e
+        @mailbox.logger.warn({ context: @mailbox.context, action: 'Disconnected. Resetting...', error: e.message, error_backtrace: e.backtrace })
+
+        reset
+        setup
+      end
+
+      private
+
+      def wait_for_new_messages
+        sleep 60
+      end
+
+      def backoff
+        sleep backoff_secs
+      end
+
+      def backoff_secs
+        [60 * 10, 2**throttled_count].min
+      end
+
+      def reset
+        @token = nil
+        @throttled_count = 0
+      end
+
+      def setup
+        @mailbox.logger.info({ context: @mailbox.context, action: 'Retrieving OAuth2 token...' })
+
+        @token = client.client_credentials.get_token({ scope: SCOPE })
+      end
+
+      def client
+        @client ||= OAuth2::Client.new(client_id, client_secret,
+                                       site: 'https://login.microsoftonline.com',
+                                       authorize_url: "/#{tenant_id}/oauth2/v2.0/authorize",
+                                       token_url: "/#{tenant_id}/oauth2/v2.0/token",
+                                       auth_scheme: :basic_auth)
+      end
+
+      def inbox_options
+        mailbox.inbox_options
+      end
+
+      def tenant_id
+        inbox_options[:tenant_id]
+      end
+
+      def client_id
+        inbox_options[:client_id]
+      end
+
+      def client_secret
+        inbox_options[:client_secret]
+      end
+
+      def process_mailbox
+        return unless @new_message_handler
+
+        @mailbox.logger.info({ context: @mailbox.context, action: 'Processing started' })
+
+        new_messages.each do |msg|
+          success = @new_message_handler.call(msg)
+          handle_delivered(msg) if success
+        end
+      end
+
+      def handle_delivered(msg)
+        mark_as_read(msg)
+        delete_message(msg) if @mailbox.delete_after_delivery
+      end
+
+      def delete_message(msg)
+        token.delete(msg_url(msg.uid))
+      end
+
+      def mark_as_read(msg)
+        token.patch(msg_url(msg.uid),
+                    headers: { 'Content-Type' => 'application/json' },
+                    body: { isRead: true }.to_json)
+      end
+
+      def new_messages
+        messages_for_ids(new_message_ids)
+      end
+
+      # Yields a page of message IDs at a time
+      def new_message_ids
+        url = unread_messages_url
+
+        Enumerator.new do |block|
+          loop do
+            messages, next_page_url = unread_messages(url: url)
+            messages.each { |msg| block.yield msg }
+
+            break unless next_page_url
+
+            url = next_page_url
+          end
+        end
+      end
+
+      def unread_messages(url:)
+        body = get(url)
+
+        return [[], nil] unless body
+
+        all_unread = body['value'].map { |msg| msg['id'] }
+        to_deliver = all_unread.select { |uid| @mailbox.deliver?(uid) }
+        @mailbox.logger.info({ context: @mailbox.context, action: 'Getting new messages',
+                               unread: { count: all_unread.count, ids: all_unread },
+                               to_be_delivered: { count: to_deliver.count, ids: to_deliver } })
+        [to_deliver, body[NEXT_PAGE_KEY]]
+      rescue TypeError, JSON::ParserError => e
+        log_exception('Error parsing JSON response', e)
+        [[], nil]
+      end
+
+      # Returns the JSON response
+      def get(url)
+        response = token.get(url, { raise_errors: false })
+
+        case response.status
+        when 429
+          raise TooManyRequestsError
+        when 400..599
+          raise OAuth2::Error, response
+        end
+
+        return unless response.body
+
+        body = JSON.parse(response.body)
+
+        raise TypeError, 'Response did not contain value hash' unless body.is_a?(Hash) && body.key?('value')
+
+        body
+      end
+
+      def messages_for_ids(message_ids)
+        message_ids.each_with_object([]) do |id, arr|
+          response = token.get(rfc822_msg_url(id))
+
+          arr << ::MailRoom::Message.new(uid: id, body: response.body)
+        end
+      end
+
+      def base_url
+        "https://graph.microsoft.com/v1.0/users/#{mailbox.email}/mailFolders/#{mailbox.name}/messages"
+      end
+
+      def unread_messages_url
+        "#{base_url}?$filter=isRead eq false"
+      end
+
+      def msg_url(id)
+        # Attempting to use the base_url fails with "The OData request is not supported"
+        "https://graph.microsoft.com/v1.0/users/#{mailbox.email}/messages/#{id}"
+      end
+
+      def rfc822_msg_url(id)
+        # Attempting to use the base_url fails with "The OData request is not supported"
+        "#{msg_url(id)}/$value"
+      end
+
+      def log_exception(message, exception)
+        @mailbox.logger.warn({ context: @mailbox.context, message: message, exception: exception.to_s })
+      end
+    end
+  end
+end

--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency             "net-imap", ">= 0.2.1"
+  gem.add_dependency             "oauth2", "~> 1.4.4"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.9"
@@ -32,4 +33,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "redis-namespace"
   gem.add_development_dependency "pg"
   gem.add_development_dependency "charlock_holmes"
+  gem.add_development_dependency "webmock"
 end

--- a/spec/lib/mailbox_watcher_spec.rb
+++ b/spec/lib/mailbox_watcher_spec.rb
@@ -1,61 +1,77 @@
 require 'spec_helper'
 
 describe MailRoom::MailboxWatcher do
-  let(:mailbox) {build_mailbox}
+  context 'with IMAP configured' do
+    let(:mailbox) {build_mailbox}
 
-  describe '#running?' do
-    it 'is false by default' do
-      watcher = MailRoom::MailboxWatcher.new(mailbox)
-      expect(watcher.running?).to eq(false)
+    describe '#running?' do
+      it 'is false by default' do
+        watcher = MailRoom::MailboxWatcher.new(mailbox)
+        expect(watcher.running?).to eq(false)
+      end
+    end
+
+    describe '#run' do
+      let(:imap) {stub(:login => true, :select => true)}
+      let(:watcher) {MailRoom::MailboxWatcher.new(mailbox)}
+
+      before :each do
+        Net::IMAP.stubs(:new).returns(imap) # prevent connection
+      end
+
+      it 'loops over wait while running' do
+        connection = MailRoom::IMAP::Connection.new(mailbox)
+
+        MailRoom::IMAP::Connection.stubs(:new).returns(connection)
+
+        watcher.expects(:running?).twice.returns(true, false)
+        connection.expects(:wait).once
+        connection.expects(:on_new_message).once
+
+        watcher.run
+        watcher.watching_thread.join # wait for finishing run
+      end
+    end
+
+    describe '#quit' do
+      let(:imap) {stub(:login => true, :select => true)}
+      let(:watcher) {MailRoom::MailboxWatcher.new(mailbox)}
+
+      before :each do
+        Net::IMAP.stubs(:new).returns(imap) # prevent connection
+      end
+
+      it 'closes and waits for the connection' do
+        connection = MailRoom::IMAP::Connection.new(mailbox)
+        connection.stubs(:wait)
+        connection.stubs(:quit)
+
+        MailRoom::IMAP::Connection.stubs(:new).returns(connection)
+
+        watcher.run
+
+        expect(watcher.running?).to eq(true)
+
+        connection.expects(:quit)
+
+        watcher.quit
+
+        expect(watcher.running?).to eq(false)
+      end
     end
   end
 
-  describe '#run' do
-    let(:imap) {stub(:login => true, :select => true)}
-    let(:watcher) {MailRoom::MailboxWatcher.new(mailbox)}
+  context 'with Microsoft Graph configured' do
+    let(:mailbox) { build_mailbox(REQUIRED_MICROSOFT_GRAPH_DEFAULTS) }
 
-    before :each do
-      Net::IMAP.stubs(:new).returns(imap) # prevent connection
-    end
+    subject { described_class.new(mailbox) }
 
-    it 'loops over wait while running' do
-      connection = MailRoom::IMAP::Connection.new(mailbox)
+    it 'initializes a Microsoft Graph connection' do
+      connection = stub(on_new_message: nil)
 
-      MailRoom::IMAP::Connection.stubs(:new).returns(connection)
+      MailRoom::MicrosoftGraph::Connection.stubs(:new).returns(connection)
 
-      watcher.expects(:running?).twice.returns(true, false)
-      connection.expects(:wait).once
-      connection.expects(:on_new_message).once
-
-      watcher.run
-      watcher.watching_thread.join # wait for finishing run
-    end
-  end
-
-  describe '#quit' do
-    let(:imap) {stub(:login => true, :select => true)}
-    let(:watcher) {MailRoom::MailboxWatcher.new(mailbox)}
-
-    before :each do
-      Net::IMAP.stubs(:new).returns(imap) # prevent connection
-    end
-
-    it 'closes and waits for the connection' do
-      connection = MailRoom::IMAP::Connection.new(mailbox)
-      connection.stubs(:wait)
-      connection.stubs(:quit)
-
-      MailRoom::IMAP::Connection.stubs(:new).returns(connection)
-
-      watcher.run
-
-      expect(watcher.running?).to eq(true)
-
-      connection.expects(:quit)
-
-      watcher.quit
-
-      expect(watcher.running?).to eq(false)
+      expect(subject.send(:connection)).to eq(connection)
     end
   end
 end

--- a/spec/lib/microsoft_graph/connection_spec.rb
+++ b/spec/lib/microsoft_graph/connection_spec.rb
@@ -47,6 +47,30 @@ describe MailRoom::MicrosoftGraph::Connection do
       connection.stubs(:wait_for_new_messages)
     end
 
+    describe 'poll interval' do
+      it 'defaults to 60 seconds' do
+        expect(connection.send(:poll_interval)).to eq(60)
+      end
+
+      context 'interval set to 10' do
+        let(:options) do
+          {
+            inbox_method: :microsoft_graph,
+            inbox_options: {
+              tenant_id: '98776',
+              client_id: '12345',
+              client_secret: 'MY-SECRET',
+              poll_interval: '10'
+            }
+          }
+        end
+
+        it 'sets the poll interval to 10' do
+          expect(connection.send(:poll_interval)).to eq(10)
+        end
+      end
+    end
+
     context 'with a single message' do
       let(:message_id) { SecureRandom.hex }
       let(:unread_messages_body) { { value: ['id' => message_id] } }

--- a/spec/lib/microsoft_graph/connection_spec.rb
+++ b/spec/lib/microsoft_graph/connection_spec.rb
@@ -132,7 +132,7 @@ describe MailRoom::MicrosoftGraph::Connection do
       end
     end
 
-    context 'invald JSON response' do
+    context 'invalid JSON response' do
       let(:body) { 'this is something' }
 
       it 'ignores the message and logs a warning' do

--- a/spec/lib/microsoft_graph/connection_spec.rb
+++ b/spec/lib/microsoft_graph/connection_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'spec_helper'
+require 'json'
+require 'webmock/rspec'
+
+describe MailRoom::MicrosoftGraph::Connection do
+  let(:tenant_id) { options[:inbox_options][:tenant_id] }
+  let(:options) do
+    {
+      delete_after_delivery: true,
+      expunge_deleted: true
+    }.merge(REQUIRED_MICROSOFT_GRAPH_DEFAULTS)
+  end
+  let(:mailbox) { build_mailbox(options) }
+  let(:base_url) { 'https://graph.microsoft.com/v1.0/users/user@example.com/mailFolders/inbox/messages' }
+  let(:message_base_url) { 'https://graph.microsoft.com/v1.0/users/user@example.com/messages' }
+
+  before do
+    WebMock.enable!
+  end
+
+  context '#wait' do
+    let(:connection) { described_class.new(mailbox) }
+    let(:uid) { 1 }
+    let(:access_token) { SecureRandom.hex }
+    let(:refresh_token) { SecureRandom.hex }
+    let(:expires_in) { Time.now + 3600 }
+    let(:unread_messages_body) { '' }
+    let(:status) { 200 }
+    let!(:stub_token) do
+      stub_request(:post, "https://login.microsoftonline.com/#{tenant_id}/oauth2/v2.0/token").to_return(
+        body: { 'access_token' => access_token, 'refresh_token' => refresh_token, 'expires_in' => expires_in }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+    let!(:stub_unread_messages_request) do
+      stub_request(:get, "#{base_url}?$filter=isRead%20eq%20false").to_return(
+        status: status,
+        body: unread_messages_body.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    before do
+      connection.stubs(:wait_for_new_messages)
+    end
+
+    context 'with a single message' do
+      let(:message_id) { SecureRandom.hex }
+      let(:unread_messages_body) { { value: ['id' => message_id] } }
+      let(:message_url) { "#{message_base_url}/#{message_id}" }
+      let(:message_body) { 'hello world' }
+
+      it 'requests message ID' do
+        stub_get = stub_request(:get, "#{message_url}/$value").to_return(
+          status: 200,
+          body: message_body
+        )
+        stub_patch = stub_request(:patch, message_url).with(body: { "isRead": true }.to_json)
+        stub_delete = stub_request(:delete, message_url)
+        message_count = 0
+
+        connection.on_new_message do |message|
+          message_count += 1
+          expect(message.uid).to eq(message_id)
+          expect(message.body).to eq(message_body)
+        end
+
+        connection.wait
+
+        assert_requested(stub_token)
+        assert_requested(stub_unread_messages_request)
+        assert_requested(stub_get)
+        assert_requested(stub_patch)
+        assert_requested(stub_delete)
+        expect(message_count).to eq(1)
+      end
+    end
+
+    context 'with multiple pages of messages' do
+      let(:message_ids) { [SecureRandom.hex, SecureRandom.hex] }
+      let(:next_page_url) { 'https://graph.microsoft.com/v1.0/nextPage' }
+      let(:unread_messages_body) { { value: ['id' => message_ids.first], '@odata.nextLink' => next_page_url } }
+      let(:message_body) { 'hello world' }
+
+      it 'requests message ID' do
+        stub_request(:get, next_page_url).to_return(
+          status: 200,
+          body: { value: ['id' => message_ids[1]] }.to_json
+        )
+
+        stubs = []
+        message_ids.each do |message_id|
+          rfc822_msg_url = "#{message_base_url}/#{message_id}/$value"
+          stubs << stub_request(:get, rfc822_msg_url).to_return(
+            status: 200,
+            body: message_body
+          )
+
+          msg_url = "#{message_base_url}/#{message_id}"
+          stubs << stub_request(:patch, msg_url).with(body: { "isRead": true }.to_json)
+          stubs << stub_request(:delete, msg_url)
+        end
+
+        message_count = 0
+
+        connection.on_new_message do |message|
+          expect(message.uid).to eq(message_ids[message_count])
+          expect(message.body).to eq(message_body)
+          message_count += 1
+        end
+
+        connection.wait
+
+        stubs.each { |stub| assert_requested(stub) }
+        expect(message_count).to eq(2)
+      end
+    end
+
+    context 'too many requests' do
+      let(:status) { 429 }
+
+      it 'backs off' do
+        connection.expects(:backoff)
+
+        connection.on_new_message {}
+        connection.wait
+
+        expect(connection.throttled_count).to eq(1)
+      end
+    end
+
+    context 'invald JSON response' do
+      let(:body) { 'this is something' }
+
+      it 'ignores the message and logs a warning' do
+        mailbox.logger.expects(:warn)
+
+        connection.on_new_message {}
+        connection.wait
+      end
+    end
+
+    context '500 error' do
+      let(:status) { 500 }
+
+      it 'resets the state and logs a warning' do
+        connection.expects(:reset)
+        connection.expects(:setup)
+        mailbox.logger.expects(:warn)
+
+        connection.on_new_message {}
+        connection.wait
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,16 @@ REQUIRED_MAILBOX_DEFAULTS = {
   :password => "password123"
 }
 
+REQUIRED_MICROSOFT_GRAPH_DEFAULTS = {
+  password: nil,
+  inbox_method: :microsoft_graph,
+  inbox_options: {
+    tenant_id: '98776',
+    client_id: '12345',
+    client_secret: 'MY-SECRET',
+  }.freeze
+}.freeze
+
 def build_mailbox(options = {})
   MailRoom::Mailbox.new(REQUIRED_MAILBOX_DEFAULTS.merge(options))
 end


### PR DESCRIPTION
This commit adds support for reading a Microsoft Office 365 or Exchange
Online mailbox via the Microsoft Graph REST API
(https://docs.microsoft.com/en-us/graph/use-the-api). Authentication
occurs via a OAuth2 service account.