### PR TITLE
Improve Microsoft Graph error handling

### DIFF
--- a/lib/mail_room/connection.rb
+++ b/lib/mail_room/connection.rb
@@ -16,8 +16,6 @@ module MailRoom
       raise NotImplementedError
     end
 
-    def quit
-      raise NotImplementedError
-    end
+    def quit; end
   end
 end

--- a/lib/mail_room/microsoft_graph/connection.rb
+++ b/lib/mail_room/microsoft_graph/connection.rb
@@ -32,7 +32,7 @@ module MailRoom
         @mailbox.logger.warn({ context: @mailbox.context, action: 'Too many requests, backing off...', backoff_s: backoff_secs, error: e.message, error_backtrace: e.backtrace })
 
         backoff
-      rescue OAuth2::Error, IOError => e
+      rescue IOError => e
         @mailbox.logger.warn({ context: @mailbox.context, action: 'Disconnected. Resetting...', error: e.message, error_backtrace: e.backtrace })
 
         reset
@@ -166,8 +166,9 @@ module MailRoom
       def get(url)
         response = token.get(url, { raise_errors: false })
 
+        # https://docs.microsoft.com/en-us/graph/errors
         case response.status
-        when 429
+        when 509, 429
           raise TooManyRequestsError
         when 400..599
           raise OAuth2::Error, response


### PR DESCRIPTION
If the wrong credentials or permissions are set for a Microsoft Graph
inbox, MailRoom will go into a tight loop of retrying the request to no
avail. https://docs.microsoft.com/en-us/graph/errors lists all the
possible errors. In most cases, we just want to terminate with a hard
failure since there is something the admin needs to check.