### PR TITLE
Revert "Fix warnings when loading net/protocol"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.5
   - 2.6
   - 2.7
   - 3.0

--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -28,9 +28,6 @@ Gem::Specification.new do |gem|
 
   # for testing delivery methods
   gem.add_development_dependency "faraday"
-  # Ruby v3.0.0 made net-http a default gem. This dependency is needed to eliminate
-  # warnings when faraday is used. See https://github.com/lostisland/faraday-net_http/pull/5.
-  gem.add_development_dependency "net-http", "~> 0.1"
   gem.add_development_dependency "mail"
   gem.add_development_dependency "letter_opener"
   gem.add_development_dependency "redis", "~> 3.3.1"


### PR DESCRIPTION
Reverts tpitale/mail_room#123

This update is a bit of a pain with Ruby 2.7 because the newer `uri` gem pulled in by `net-http` can cause these errors:

```
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/runtime.rb:302:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.10.1. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
```

Until `uri` finally becomes a default gem in Ruby/Rubygems (reverted in https://github.com/ruby/ruby/commit/bcfe94b7f20fa3a581fc5d6f2aef837327bfb770), I think we need to stick with the standard version.