### PR TITLE
Fix database in redis url

### DIFF
--- a/lib/mail_room/delivery/sidekiq.rb
+++ b/lib/mail_room/delivery/sidekiq.rb
@@ -8,16 +8,17 @@ module MailRoom
     # Sidekiq Delivery method
     # @author Douwe Maan
     class Sidekiq
-      Options = Struct.new(:redis_url, :namespace, :sentinels, :queue, :worker, :logger) do
+      Options = Struct.new(:redis_url, :namespace, :sentinels, :queue, :worker, :logger, :redis_db) do
         def initialize(mailbox)
           redis_url = mailbox.delivery_options[:redis_url] || "redis://localhost:6379"
+          redis_db  = mailbox.delivery_options[:redis_db] || 0
           namespace = mailbox.delivery_options[:namespace]
           sentinels = mailbox.delivery_options[:sentinels]
           queue     = mailbox.delivery_options[:queue] || "default"
           worker    = mailbox.delivery_options[:worker]
           logger = mailbox.logger
 
-          super(redis_url, namespace, sentinels, queue, worker, logger)
+          super(redis_url, namespace, sentinels, queue, worker, logger, redis_db)
         end
       end
 
@@ -45,7 +46,7 @@ module MailRoom
       def client
         @client ||= begin
           sentinels = options.sentinels
-          redis_options = { url: options.redis_url }
+          redis_options = { url: options.redis_url, db: options.redis_db }
           redis_options[:sentinels] = sentinels if sentinels
 
           redis = ::Redis.new(redis_options)

--- a/spec/lib/delivery/sidekiq_spec.rb
+++ b/spec/lib/delivery/sidekiq_spec.rb
@@ -8,23 +8,45 @@ describe MailRoom::Delivery::Sidekiq do
 
   describe '#options' do
     let(:redis_url) { 'redis://localhost' }
+    let(:redis_options) { { redis_url: redis_url } }
 
     context 'when only redis_url is specified' do
       let(:mailbox) {
         build_mailbox(
           delivery_method: :sidekiq,
-          delivery_options: {
-            redis_url: redis_url
-          }
+          delivery_options: redis_options
         )
       }
 
-      it 'client has same specified redis_url' do
-        expect(redis.client.options[:url]).to eq(redis_url)
+      context 'with simple redis url' do
+        it 'client has same specified redis_url' do
+          expect(redis.client.options[:url]).to eq(redis_url)
+        end
+
+        it 'client is a instance of RedisNamespace class' do
+          expect(redis).to be_a ::Redis
+        end
+
+        it 'connection has correct values' do
+          expect(redis.connection[:host]).to eq('localhost')
+          expect(redis.connection[:db]).to eq(0)
+        end
       end
 
-      it 'client is a instance of RedisNamespace class' do
-        expect(redis).to be_a ::Redis
+      context 'with redis_db specified in options' do
+        before do
+          redis_options[:redis_db] = 4
+        end
+
+        it 'client has correct redis_url' do
+          expect(redis.client.options[:url]).to eq(redis_url)
+        end
+
+
+        it 'connection has correct values' do
+          expect(redis.connection[:host]).to eq('localhost')
+          expect(redis.connection[:db]).to eq(4)
+        end
       end
     end
 


### PR DESCRIPTION
This MR fixes Redis connection. When a `db` is specified in a url, it is correctly set in `client` but not `connection`.

Example:

```ruby
redis = Redis.new(url: 'redis://localhost?db=4')

redis.client.options[:url]
=> "redis://localhost?db=4" # this is correct

 redis.connection
=> {:host=>"localhost", :port=>6379, :db=>0, :id=>"redis://localhost:6379/0", :location=>"localhost:6379"} # db here is incorrect
```

When the db is passed as a separated option, it works:

```ruby
redis = Redis.new(url: 'redis://localhost?db=4', db: 4)

redis.client.options[:url]
=> "redis://localhost?db=4"

redis.connection
=> {:host=>"localhost", :port=>6379, :db=>4, :id=>"redis://localhost:6379/4", :location=>"localhost:6379"}
```