### PR TITLE
Speed up process termination time when Microsoft Graph enabled

### DIFF
--- a/lib/mail_room/connection.rb
+++ b/lib/mail_room/connection.rb
@@ -6,16 +6,23 @@ module MailRoom
 
     def initialize(mailbox)
       @mailbox = mailbox
+      @stopped = false
     end
 
     def on_new_message(&block)
       @new_message_handler = block
     end
 
+    def stopped?
+      @stopped
+    end
+
     def wait
       raise NotImplementedError
     end
 
-    def quit; end
+    def quit
+      @stopped = true
+    end
   end
 end


### PR DESCRIPTION
By default, the Microsoft Graph connection sleeps for 60 seconds before
polling for more data. If the process is terminated, it can take another
60 seconds to terminate.

We can speed this up by waking up every second and and checking whether
to terminate.