### PR TITLE
Add Jwt authentication support to postback delivery method

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ You will also need to install `faraday` or `letter_opener` if you use the `postb
     :delivery_options:
       :redis_url: redis://localhost:6379
       :worker: EmailReceiverWorker
+  -
+    :email: "user8@gmail.com"
+    :password: "password"
+    :name: "inbox"
+    :delivery_method: postback
+    :delivery_options:
+      :delivery_url: "http://localhost:3000/inbox"
+      :jwt_auth_header: "Mailroom-Api-Request"
+      :jwt_issuer: "mailroom"
+      :jwt_algorithm: "HS256"
+      :jwt_secret_path: "/etc/secrets/mailroom/.mailroom_secret"
 ```
 
 **Note:** If using `delete_after_delivery`, you also probably want to use

--- a/lib/mail_room/delivery/postback.rb
+++ b/lib/mail_room/delivery/postback.rb
@@ -1,11 +1,12 @@
 require 'faraday'
+require "mail_room/jwt"
 
 module MailRoom
   module Delivery
     # Postback Delivery method
     # @author Tony Pitale
     class Postback
-      Options = Struct.new(:url, :token, :username, :password, :logger, :content_type) do
+      Options = Struct.new(:url, :token, :username, :password, :logger, :content_type, :jwt) do
         def initialize(mailbox)
           url =
             mailbox.delivery_url ||
@@ -17,6 +18,8 @@ module MailRoom
             mailbox.delivery_options[:delivery_token] ||
             mailbox.delivery_options[:token]
 
+          jwt = initialize_jwt(mailbox.delivery_options)
+
           username = mailbox.delivery_options[:username]
           password = mailbox.delivery_options[:password]
 
@@ -24,15 +27,30 @@ module MailRoom
 
           content_type = mailbox.delivery_options[:content_type]
 
-          super(url, token, username, password, logger, content_type)
+          super(url, token, username, password, logger, content_type, jwt)
         end
 
         def token_auth?
           !self[:token].nil?
         end
 
+        def jwt_auth?
+          self[:jwt].valid?
+        end
+
         def basic_auth?
           !self[:username].nil? && !self[:password].nil?
+        end
+
+        private
+
+        def initialize_jwt(delivery_options)
+          ::MailRoom::JWT.new(
+            header: delivery_options[:jwt_auth_header],
+            secret_path: delivery_options[:jwt_secret_path],
+            algorithm: delivery_options[:jwt_algorithm],
+            issuer: delivery_options[:jwt_issuer]
+          )
         end
       end
 
@@ -60,12 +78,26 @@ module MailRoom
         connection.post do |request|
           request.url @delivery_options.url
           request.body = message
-          # request.options[:timeout] = 3
-          request.headers['Content-Type'] = @delivery_options.content_type unless @delivery_options.content_type.nil?
+          config_request_content_type(request)
+          config_request_jwt_auth(request)
         end
 
         @delivery_options.logger.info({ delivery_method: 'Postback', action: 'message pushed', url: @delivery_options.url })
         true
+      end
+
+      private
+
+      def config_request_content_type(request)
+        return if @delivery_options.content_type.nil?
+
+        request.headers['Content-Type'] = @delivery_options.content_type
+      end
+
+      def config_request_jwt_auth(request)
+        return unless @delivery_options.jwt_auth?
+
+        request.headers[@delivery_options.jwt.header] = @delivery_options.jwt.token
       end
     end
   end

--- a/lib/mail_room/jwt.rb
+++ b/lib/mail_room/jwt.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'securerandom'
+
+module MailRoom
+  # Responsible for validating and generating JWT token
+  class JWT
+    DEFAULT_ISSUER = 'mailroom'
+    DEFAULT_ALGORITHM = 'HS256'
+
+    attr_reader :header, :secret_path, :issuer, :algorithm
+
+    def initialize(header:, secret_path:, issuer:, algorithm:)
+      @header = header
+      @secret_path = secret_path
+      @issuer = issuer || DEFAULT_ISSUER
+      @algorithm = algorithm || DEFAULT_ALGORITHM
+    end
+
+    def valid?
+      [@header, @secret_path, @issuer, @algorithm].none?(&:nil?)
+    end
+
+    def token
+      return nil unless valid?
+
+      secret = Base64.strict_decode64(File.read(@secret_path).chomp)
+      payload = { nonce: SecureRandom.hex(12), iss: @issuer }
+      ::JWT.encode payload, secret, @algorithm
+    end
+  end
+end

--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -19,11 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency             "net-imap", ">= 0.2.1"
   gem.add_dependency             "oauth2", "~> 1.4.4"
-
-  # Pinning io-wait to 0.1.0, which is the last version to support Ruby < 3
-  gem.add_dependency              "io-wait", "~> 0.1.0"
-
-  gem.add_dependency              "jwt", ">= 2.0"
+  gem.add_dependency             "jwt", ">= 2.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.9"

--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -20,6 +20,11 @@ Gem::Specification.new do |gem|
   gem.add_dependency             "net-imap", ">= 0.2.1"
   gem.add_dependency             "oauth2", "~> 1.4.4"
 
+  # Pinning io-wait to 0.1.0, which is the last version to support Ruby < 3
+  gem.add_dependency              "io-wait", "~> 0.1.0"
+
+  gem.add_dependency              "jwt", ">= 2.0"
+
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.9"
   gem.add_development_dependency "rubocop", "~> 1.11"

--- a/spec/fixtures/jwt_secret
+++ b/spec/fixtures/jwt_secret
@@ -1,0 +1,1 @@
+aGVsbG93b3JsZA==

--- a/spec/lib/jwt_spec.rb
+++ b/spec/lib/jwt_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+require 'mail_room/jwt'
+
+describe MailRoom::JWT do
+  let(:secret_path) { File.expand_path('../fixtures/jwt_secret', File.dirname(__FILE__)) }
+  let(:secret) { Base64.strict_decode64(File.read(secret_path).chomp) }
+
+  let(:standard_config) do
+    {
+      secret_path: secret_path,
+      issuer: 'mailroom',
+      header: 'Mailroom-Api-Request',
+      algorithm: 'HS256'
+    }
+  end
+
+  describe '#token' do
+    let(:jwt) { described_class.new(**standard_config) }
+
+    it 'generates a valid jwt token' do
+      token = jwt.token
+      expect(token).not_to be_empty
+
+      payload = nil
+      expect do
+        payload = JWT.decode(token, secret, true, iss: 'mailroom', verify_iss: true, algorithm: 'HS256')
+      end.not_to raise_error
+      expect(payload).to be_an(Array)
+      expect(payload).to match(
+        [
+          a_hash_including(
+            'iss' => 'mailroom',
+            'nonce' => be_a(String)
+          ),
+          { 'alg' => 'HS256' }
+        ]
+      )
+    end
+
+    it 'generates a different token for each invocation' do
+      expect(jwt.token).not_to eql(jwt.token)
+    end
+  end
+
+  describe '#valid?' do
+    it 'returns true if all essential components are present' do
+      jwt = described_class.new(**standard_config)
+      expect(jwt.valid?).to eql(true)
+    end
+
+    it 'returns true if header and secret path are present' do
+      jwt = described_class.new(
+        secret_path: secret_path,
+        header: 'Mailroom-Api-Request',
+        issuer: nil,
+        algorithm: nil
+      )
+      expect(jwt.valid?).to eql(true)
+      expect(jwt.issuer).to eql(described_class::DEFAULT_ISSUER)
+      expect(jwt.algorithm).to eql(described_class::DEFAULT_ALGORITHM)
+    end
+
+    it 'returns false if either header or secret_path are missing' do
+      expect(described_class.new(
+        secret_path: nil,
+        header: 'Mailroom-Api-Request',
+        issuer: nil,
+        algorithm: nil
+      ).valid?).to eql(false)
+      expect(described_class.new(
+        secret_path: secret_path,
+        header: nil,
+        issuer: nil,
+        algorithm: nil
+      ).valid?).to eql(false)
+    end
+  end
+end


### PR DESCRIPTION
Hi there 👋 

I'm looking forward to add JWT token support to postback delivery method. This change is essential for an initiative at GitLab to convert the push-directly-to-redis way to webhook style. The full context is available at https://gitlab.com/groups/gitlab-com/gl-infra/-/epics/644. 

The mailroom gem already supports postback strategy that delivers the mail contents via HTTP request. However, mail_room gem uses Faraday and its [token_auth](https://www.rubydoc.info/github/lostisland/faraday/Faraday%2FConnection:token_auth) authentication method. This method adds a configured token to Authorization header: `Authorization: Token token="something"`. Unfortunately, we are following a different approach for authentication. We are using JWT tokens for internal APIs. The token is generated using HS256 algorithm using a shard symmetric secret file. The tokens are then embedded into a custom request header. Since GitLab as a whole is a collection of different services, each service uses a different secret and embeds into a different header.

I would like to propose to add the following configurations to the postback delivery method:

```
    :delivery_options:
      :delivery_url: "http://localhost:3000/inbox"
      :jwt_auth_header: "Gitlab-Mailroom-Api-Request"
      :jwt_issuer: "gitlab-mailroom"
      :jwt_algorithm: "HS256"
      :jwt_secret_path: "/etc/gitlab-secrets/mailroom/.gitlab_mailroom_secret"
```

The request headers look something like:

```
{ 
  "Gitlab-Mailroom-Api-Request" =>  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
}
```

The meanings of each configuration is self-explanatory. At the moment, I implemented just subset of JWT [reserved claims](https://auth0.com/docs/security/tokens/json-web-tokens/json-web-token-claims#reserved-claims) and haven't supported custom payload. I would love to add more to make the solution becomes more useful for everyone. As a result, the official JWT gem is added as a dependency of this gem. 

cc @stanhu 