### PR TITLE
Add `iat` payload to postback JWT authentication

### DIFF
--- a/lib/mail_room/jwt.rb
+++ b/lib/mail_room/jwt.rb
@@ -26,7 +26,11 @@ module MailRoom
       return nil unless valid?
 
       secret = Base64.strict_decode64(File.read(@secret_path).chomp)
-      payload = { nonce: SecureRandom.hex(12), iss: @issuer }
+      payload = {
+        nonce: SecureRandom.hex(12),
+        iat: Time.now.to_i, # https://github.com/jwt/ruby-jwt#issued-at-claim
+        iss: @issuer
+      }
       ::JWT.encode payload, secret, @algorithm
     end
   end

--- a/spec/lib/jwt_spec.rb
+++ b/spec/lib/jwt_spec.rb
@@ -24,14 +24,15 @@ describe MailRoom::JWT do
 
       payload = nil
       expect do
-        payload = JWT.decode(token, secret, true, iss: 'mailroom', verify_iss: true, algorithm: 'HS256')
+        payload = JWT.decode(token, secret, true, iss: 'mailroom', verify_iat: true, verify_iss: true, algorithm: 'HS256')
       end.not_to raise_error
       expect(payload).to be_an(Array)
       expect(payload).to match(
         [
           a_hash_including(
             'iss' => 'mailroom',
-            'nonce' => be_a(String)
+            'nonce' => be_a(String),
+            'iat' => be_a(Integer)
           ),
           { 'alg' => 'HS256' }
         ]


### PR DESCRIPTION
This PR is the following-up PR of https://github.com/tpitale/mail_room/pull/134. In the previous PR, I implemented JWT authentication support for postback strategy. The new authentication works well, but expose a potential attack vector such as replay attacks. A good way to prevent such attacks is to make token time-limited. JWT provides two ways of doing this via the claims:
- `exp`: [Expiration Time Claim](https://github.com/jwt/ruby-jwt#expiration-time-claim). This claim controls the expiration of the token. It is the most straight-forward way. However, the expiration time is determined when the token is issued. It means the clients are a bit inflexible. We also need to add one more config.
- `iat`: [Issued At Claim](https://github.com/jwt/ruby-jwt#issued-at-claim). The timestamp when the token is issued is embedded into the payload. The clients examine the payload for the token age and act as their wills. As the limiting logic is delegated to the clients, we don't need a new config for expiration time.

The second approach seems most reasonable.
 