### PR TITLE
Upgrade redis-rb dependency to v4.x

### DIFF
--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "faraday"
   gem.add_development_dependency "mail"
   gem.add_development_dependency "letter_opener"
-  gem.add_development_dependency "redis", "~> 3.3.1"
+  gem.add_development_dependency "redis", "~> 4"
   gem.add_development_dependency "redis-namespace"
   gem.add_development_dependency "pg"
   gem.add_development_dependency "charlock_holmes"

--- a/spec/lib/arbitration/redis_spec.rb
+++ b/spec/lib/arbitration/redis_spec.rb
@@ -15,6 +15,7 @@ describe MailRoom::Arbitration::Redis do
 
   # Private, but we don't care.
   let(:redis) { subject.send(:client) }
+  let(:raw_client) { redis._client }
 
   describe '#deliver?' do
     context "when called the first time" do
@@ -95,7 +96,7 @@ describe MailRoom::Arbitration::Redis do
       it 'client has same specified url' do
         subject.deliver?(123)
 
-        expect(redis.client.options[:url]).to eq redis_url
+        expect(raw_client.options[:url]).to eq redis_url
       end
 
       it 'client is a instance of Redis class' do
@@ -137,10 +138,10 @@ describe MailRoom::Arbitration::Redis do
       before { ::Redis::Client::Connector::Sentinel.any_instance.stubs(:resolve).returns(sentinels) }
 
       it 'client has same specified sentinel params' do
-        expect(redis.client.instance_variable_get(:@connector)).to be_a Redis::Client::Connector::Sentinel
-        expect(redis.client.options[:host]).to eq('sentinel-master')
-        expect(redis.client.options[:password]).to eq('mypassword')
-        expect(redis.client.options[:sentinels]).to eq(sentinels)
+        expect(raw_client.instance_variable_get(:@connector)).to be_a Redis::Client::Connector::Sentinel
+        expect(raw_client.options[:host]).to eq('sentinel-master')
+        expect(raw_client.options[:password]).to eq('mypassword')
+        expect(raw_client.options[:sentinels]).to eq(sentinels)
       end
     end
   end

--- a/spec/lib/delivery/sidekiq_spec.rb
+++ b/spec/lib/delivery/sidekiq_spec.rb
@@ -4,6 +4,7 @@ require 'mail_room/delivery/sidekiq'
 describe MailRoom::Delivery::Sidekiq do
   subject { described_class.new(options) }
   let(:redis) { subject.send(:client) }
+  let(:raw_client) { redis._client }
   let(:options) { MailRoom::Delivery::Sidekiq::Options.new(mailbox) }
 
   describe '#options' do
@@ -20,7 +21,7 @@ describe MailRoom::Delivery::Sidekiq do
 
       context 'with simple redis url' do
         it 'client has same specified redis_url' do
-          expect(redis.client.options[:url]).to eq(redis_url)
+          expect(raw_client.options[:url]).to eq(redis_url)
         end
 
         it 'client is a instance of RedisNamespace class' do
@@ -39,7 +40,7 @@ describe MailRoom::Delivery::Sidekiq do
         end
 
         it 'client has correct redis_url' do
-          expect(redis.client.options[:url]).to eq(redis_url)
+          expect(raw_client.options[:url]).to eq(redis_url)
         end
 
 
@@ -87,10 +88,10 @@ describe MailRoom::Delivery::Sidekiq do
       before { ::Redis::Client::Connector::Sentinel.any_instance.stubs(:resolve).returns(sentinels) }
 
       it 'client has same specified sentinel params' do
-        expect(redis.client.instance_variable_get(:@connector)).to be_a Redis::Client::Connector::Sentinel
-        expect(redis.client.options[:host]).to eq('sentinel-master')
-        expect(redis.client.options[:password]).to eq('mypassword')
-        expect(redis.client.options[:sentinels]).to eq(sentinels)
+        expect(raw_client.instance_variable_get(:@connector)).to be_a Redis::Client::Connector::Sentinel
+        expect(raw_client.options[:host]).to eq('sentinel-master')
+        expect(raw_client.options[:password]).to eq('mypassword')
+        expect(raw_client.options[:sentinels]).to eq(sentinels)
       end
     end
 


### PR DESCRIPTION
As https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#40
describes, redis-rb v4.0 added support for `CLIENT` commands, so the
lower-level client was changed to `Redis#_client`.

This update fixes the broken tests as a result of this change.