### PR TITLE
Fix Ruby 3.0 compatibility with redis-namespace and redis-rb

### DIFF
--- a/lib/mail_room/arbitration/redis.rb
+++ b/lib/mail_room/arbitration/redis.rb
@@ -31,7 +31,7 @@ module MailRoom
         # Any subsequent failure in the instance which gets the lock will be dealt
         # with by the expiration, at which time another instance can pick up the
         # message and try again.
-        client.set(key, 1, {nx: true, ex: expiration})
+        client.set(key, 1, nx: true, ex: expiration)
       end
 
       private


### PR DESCRIPTION
Passing in keyword arguments as the last positional Hash argument is
deprecated in Ruby 3.0. redis-namespace provides backward compatibility
via ruby2_keywords, but this no longer works in Ruby 3.0.

To fix this for both Ruby 2.x and 3.x, we should just pass in keyword
arguments explicitly.