### PR TITLE
Add missing dependency requirements

### DIFF
--- a/lib/mail_room/jwt.rb
+++ b/lib/mail_room/jwt.rb
@@ -2,6 +2,8 @@
 
 require 'faraday'
 require 'securerandom'
+require 'jwt'
+require 'base64'
 
 module MailRoom
   # Responsible for validating and generating JWT token


### PR DESCRIPTION
In https://github.com/tpitale/mail_room/pull/134, I added header-based JWT authentication to postback strategy. The unit tests were green. Manual testing on GitLab codebase yielded no concerns. However, when I tried to start mail_room with vanilla [built-in binary](https://github.com/nguyenquangminh0711/mail_room/blob/c39ab4b30579f3c0a7b2826158d87de3355ecf25/bin/mail_room), the program crashes:

![Screen Shot 2022-01-19 at 12 55 22](https://user-images.githubusercontent.com/11613517/150074326-b515c672-5fdc-4f14-8e66-d26328cc6c15.png)

It turns out, I forgot to load `jwt` and `base64` before using them. It's a really silly mistake 🤦. Those two gems are already loaded in GitLab codebase. Somehow, while running full test suite in this repository, they are automatically loaded. The test fails when running `bundle exec rspec spec/lib/jwt_spec.rb` individually. 