### PR TITLE
Allow OAuth2 v2 gem

### DIFF
--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency             "net-imap", ">= 0.2.1"
-  gem.add_dependency             "oauth2", "~> 1.4.4"
+  gem.add_dependency             "oauth2", [">= 1.4.4", "< 3"]
   gem.add_dependency             "jwt", ">= 2.0"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
OAuth2 v2.0 was released a few months ago. MailRoom's use of
`OAuth2::Client` with Microsoft Graph is compatible with all the v2.0
changes: https://github.com/oauth-xx/oauth2/blob/master/CHANGELOG.md#2.0.0