### PR TITLE
Faraday API change, connection.basic_auth removed

### DIFF
--- a/lib/mail_room/delivery/postback.rb
+++ b/lib/mail_room/delivery/postback.rb
@@ -73,10 +73,18 @@ module MailRoom
         if @delivery_options.token_auth?
           connection.token_auth @delivery_options.token
         elsif @delivery_options.basic_auth?
-          connection.basic_auth(
-            @delivery_options.username,
-            @delivery_options.password
-          )
+          if defined?(connection.basic_auth)
+            connection.basic_auth(
+              @delivery_options.username,
+              @delivery_options.password
+            )
+          else
+            connection.request(
+              :authorization, :basic, 
+              @delivery_options.username,
+              @delivery_options.password
+            )
+          end
         end
 
         connection.post do |request|


### PR DESCRIPTION
Before this patch, I was getting the following error each time mail_room received a message and tried to use the `postback`to `ActionMailbox`.

<details>
<summary>(NoMethodError) connection.basic_auth(</summary>

```
#<struct MailRoom::Delivery::Postback::Options url="http://<HOST>/rails/action_mailbox/relay/inbound_emails", token=nil, username="actionmailbox", password="<PASS>", logger=#<MailRoom::Logger::Structured:0x00007f5847e80b88 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x00007f5847e80930 @datetime_format=nil>, @formatter=nil, @logdev=nil>>
#<Thread:0x00007f5847e69dc0 /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/mailbox_watcher.rb:33 run> terminated with exception (report_on_exception is true):
/home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/delivery/postback.rb:52:in `deliver': undefined method `basic_auth' for #<Faraday::Connection:0x00007f5843d31830 @parallel_manager=nil, @headers={"User-Agent"=>"Faraday v2.7.4"}, @params={}, @options=#<Faraday::RequestOptions (empty)>, @ssl=#<Faraday::SSLOptions (empty)>, @default_parallel_manager=nil, @manual_proxy=false, @builder=#<Faraday::RackBuilder:0x00007f5843d30b60 @adapter=Faraday::Adapter::NetHttp, @handlers=[Faraday::Request::UrlEncoded]>, @url_prefix=#<URI::HTTP http:/>, @proxy=nil> (NoMethodError)

          connection.basic_auth(
                    ^^^^^^^^^^^
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/mailbox.rb:109:in `deliver'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/mailbox_watcher.rb:30:in `block in run'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/connection.rb:141:in `map'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/connection.rb:141:in `process_mailbox'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/connection.rb:51:in `wait'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/mailbox_watcher.rb:35:in `block in run'
bundler: failed to load command: mail_room (/home/app/webapp/gems/ruby/3.1.0/bin/mail_room)
/home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/delivery/postback.rb:52:in `deliver': undefined method `basic_auth' for #<Faraday::Connection:0x00007f5843d31830 @parallel_manager=nil, @headers={"User-Agent"=>"Faraday v2.7.4"}, @params={}, @options=#<Faraday::RequestOptions (empty)>, @ssl=#<Faraday::SSLOptions (empty)>, @default_parallel_manager=nil, @manual_proxy=false, @builder=#<Faraday::RackBuilder:0x00007f5843d30b60 @adapter=Faraday::Adapter::NetHttp, @handlers=[Faraday::Request::UrlEncoded]>, @url_prefix=#<URI::HTTP http:/>, @proxy=nil> (NoMethodError)

          connection.basic_auth(
                    ^^^^^^^^^^^
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/mailbox.rb:109:in `deliver'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/mailbox_watcher.rb:30:in `block in run'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/connection.rb:141:in `map'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/connection.rb:141:in `process_mailbox'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/connection.rb:51:in `wait'
        from /home/app/webapp/gems/ruby/3.1.0/gems/mail_room-0.10.0/lib/mail_room/mailbox_watcher.rb:35:in `block in run'

```
</details>


According to:
https://lostisland.github.io/faraday/middleware/authentication

Faraday 2.x+ no longer support the:
`connection.basic_auth` function.

This patch just tests if `connection.basic_auth` is defined (1.x) and if so calls it, otherwise must be the 2.x version of the API.

> ## Basic Authentication

> The middleware will automatically Base64 encode your Basic username and password:

> ```
> Faraday.new(...) do |conn|
>  conn.request :authorization, :basic, 'username', 'password'
> end
```