### PR TITLE
Deprecate the use of Redis namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Delivery options:
   Required, defaults to `redis://localhost:6379`.
 - **sentinels**: A list of sentinels servers used to provide HA to Redis. (see [Sentinel Support](#sentinel-support))
   Optional.
-- **namespace**: The Redis namespace Sidekiq works under. Use the same Redis namespace that's used to configure Sidekiq.
+- **namespace**: [DEPRECATED] The Redis namespace Sidekiq works under. Use the same Redis namespace that's used to configure Sidekiq.
   Optional.
 - **queue**: The Sidekiq queue the job is pushed onto. Make sure Sidekiq actually reads off this queue.
   Required, defaults to `default`.
@@ -391,7 +391,7 @@ When running multiple instances of MailRoom against a single mailbox, to try to 
     :arbitration_options:
       # The Redis server to connect with. Defaults to redis://localhost:6379.
       :redis_url: redis://redis.example.com:6379
-      # The Redis namespace to house the Redis keys under. Optional.
+      # [DEPRECATED] The Redis namespace to house the Redis keys under. Optional.
       :namespace: mail_room
   -
     :email: "user2@gmail.com"
@@ -411,7 +411,7 @@ When running multiple instances of MailRoom against a single mailbox, to try to 
         -
           :host: 127.0.0.1
           :port: 26379
-      # The Redis namespace to house the Redis keys under. Optional.
+      # [DEPRECATED] The Redis namespace to house the Redis keys under. Optional.
       :namespace: mail_room
 ```
 

--- a/lib/mail_room/arbitration/redis.rb
+++ b/lib/mail_room/arbitration/redis.rb
@@ -9,6 +9,13 @@ module MailRoom
           namespace = mailbox.arbitration_options[:namespace]
           sentinels = mailbox.arbitration_options[:sentinels]
 
+          if namespace
+            warn <<~MSG
+              Redis namespaces are deprecated. This option will be ignored in future versions.
+              See https://github.com/sidekiq/sidekiq/issues/2586 for more details."
+            MSG
+          end
+
           super(redis_url, namespace, sentinels)
         end
       end

--- a/lib/mail_room/delivery/sidekiq.rb
+++ b/lib/mail_room/delivery/sidekiq.rb
@@ -18,6 +18,13 @@ module MailRoom
           worker    = mailbox.delivery_options[:worker]
           logger = mailbox.logger
 
+          if namespace
+            warn <<~MSG
+              Redis namespaces are deprecated. This option will be ignored in future versions.
+              See https://github.com/sidekiq/sidekiq/issues/2586 for more details."
+            MSG
+          end
+
           super(redis_url, namespace, sentinels, queue, worker, logger, redis_db)
         end
       end


### PR DESCRIPTION
As described in https://github.com/sidekiq/sidekiq/issues/2586 and http://www.mikeperham.com/2015/09/24/storing-data-with-redis/, Sidekiq 4.0 dropped the use of redis-namespace.

Let's follow suit and deprecate this dependency.