### PR TITLE
Enable token authentication with Faraday >= v2

### DIFF
--- a/lib/mail_room/delivery/postback.rb
+++ b/lib/mail_room/delivery/postback.rb
@@ -71,7 +71,7 @@ module MailRoom
         connection = Faraday.new
 
         if @delivery_options.token_auth?
-          connection.token_auth @delivery_options.token
+          config_token_auth(connection)
         elsif @delivery_options.basic_auth?
           config_basic_auth(connection)
         end
@@ -99,6 +99,17 @@ module MailRoom
         return unless @delivery_options.jwt_auth?
 
         request.headers[@delivery_options.jwt.header] = @delivery_options.jwt.token
+      end
+
+      def config_token_auth(connection)
+        if defined?(connection.token_auth)
+          connection.token_auth @delivery_options.token
+        else
+          connection.request(
+            :authorization, 'Token',
+            @delivery_options.token
+          )
+        end
       end
 
       def config_basic_auth(connection)

--- a/lib/mail_room/delivery/postback.rb
+++ b/lib/mail_room/delivery/postback.rb
@@ -102,6 +102,7 @@ module MailRoom
       end
 
       def config_token_auth(connection)
+        # connection.token_auth was removed in Faraday v2 in favor of connection.request(:authorization, 'Token', token)
         if defined?(connection.token_auth)
           connection.token_auth @delivery_options.token
         else


### PR DESCRIPTION
**Previous behavior:**
`delivery_method=postback` with token auth and Faraday >= v2.0.0 breaks because the`connection.token_auth` method was removed in Faraday v2.0.0.

**New behavior:**
Postback token auth works for Faraday v1.x and v2.x. Uses existence of `connection.token_auth` method to branch to either the preexisting token auth method or the newer token auth method `connection.request(:authorization, 'Token', @delivery_options.token)`.