### PR TITLE
Add support for sentinel_username and sentinel_password parameters

### DIFF
--- a/lib/mail_room/arbitration/redis.rb
+++ b/lib/mail_room/arbitration/redis.rb
@@ -3,11 +3,13 @@ require "redis"
 module MailRoom
   module Arbitration
     class Redis
-      Options = Struct.new(:redis_url, :namespace, :sentinels) do
+      Options = Struct.new(:redis_url, :namespace, :sentinels, :sentinel_username, :sentinel_password) do
         def initialize(mailbox)
           redis_url = mailbox.arbitration_options[:redis_url] || "redis://localhost:6379"
           namespace = mailbox.arbitration_options[:namespace]
           sentinels = mailbox.arbitration_options[:sentinels]
+          sentinel_username = mailbox.arbitration_options[:sentinel_username]
+          sentinel_password = mailbox.arbitration_options[:sentinel_password]
 
           if namespace
             warn <<~MSG
@@ -16,7 +18,7 @@ module MailRoom
             MSG
           end
 
-          super(redis_url, namespace, sentinels)
+          super(redis_url, namespace, sentinels, sentinel_username, sentinel_password)
         end
       end
 
@@ -48,6 +50,8 @@ module MailRoom
           sentinels = options.sentinels
           redis_options = { url: options.redis_url }
           redis_options[:sentinels] = sentinels if sentinels
+          redis_options[:sentinel_username] = options.sentinel_username if options.sentinel_username
+          redis_options[:sentinel_password] = options.sentinel_password if options.sentinel_password
 
           redis = ::Redis.new(redis_options)
 

--- a/lib/mail_room/delivery/sidekiq.rb
+++ b/lib/mail_room/delivery/sidekiq.rb
@@ -8,12 +8,14 @@ module MailRoom
     # Sidekiq Delivery method
     # @author Douwe Maan
     class Sidekiq
-      Options = Struct.new(:redis_url, :namespace, :sentinels, :queue, :worker, :logger, :redis_db) do
+      Options = Struct.new(:redis_url, :namespace, :sentinels, :queue, :worker, :logger, :redis_db, :sentinel_username, :sentinel_password) do
         def initialize(mailbox)
           redis_url = mailbox.delivery_options[:redis_url] || "redis://localhost:6379"
           redis_db  = mailbox.delivery_options[:redis_db] || 0
           namespace = mailbox.delivery_options[:namespace]
           sentinels = mailbox.delivery_options[:sentinels]
+          sentinel_username = mailbox.delivery_options[:sentinel_username]
+          sentinel_password = mailbox.delivery_options[:sentinel_password]
           queue     = mailbox.delivery_options[:queue] || "default"
           worker    = mailbox.delivery_options[:worker]
           logger = mailbox.logger
@@ -25,7 +27,7 @@ module MailRoom
             MSG
           end
 
-          super(redis_url, namespace, sentinels, queue, worker, logger, redis_db)
+          super(redis_url, namespace, sentinels, queue, worker, logger, redis_db, sentinel_username, sentinel_password)
         end
       end
 
@@ -55,6 +57,8 @@ module MailRoom
           sentinels = options.sentinels
           redis_options = { url: options.redis_url, db: options.redis_db }
           redis_options[:sentinels] = sentinels if sentinels
+          redis_options[:sentinel_username] = options.sentinel_username if options.sentinel_username
+          redis_options[:sentinel_password] = options.sentinel_password if options.sentinel_password
 
           redis = ::Redis.new(redis_options)
 

--- a/mail_room.gemspec
+++ b/mail_room.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "faraday"
   gem.add_development_dependency "mail"
   gem.add_development_dependency "letter_opener"
-  gem.add_development_dependency "redis", "~> 4"
+  gem.add_development_dependency "redis", "~> 5"
   gem.add_development_dependency "redis-namespace"
   gem.add_development_dependency "pg"
   gem.add_development_dependency "charlock_holmes"

--- a/spec/lib/arbitration/redis_spec.rb
+++ b/spec/lib/arbitration/redis_spec.rb
@@ -144,6 +144,30 @@ describe MailRoom::Arbitration::Redis do
         expect(raw_client.config.password).to eq('mypassword')
         expect(raw_client.config.sentinels.map(&:server_url)).to eq(["redis://10.0.0.1:26379"])
       end
+
+      context 'with separate Sentinel username and password' do
+        let(:sentinel_username) { 'my-sentinel-user' }
+        let(:sentinel_password) { 'my-sentinel-pass' }
+        let(:mailbox) {
+          build_mailbox(
+            arbitration_options: {
+              redis_url: redis_url,
+              sentinels: sentinels,
+              sentinel_username: sentinel_username,
+              sentinel_password: sentinel_password
+            }
+          )
+        }
+
+        it 'client uses Sentinel username and password' do
+          expect(raw_client.config).to be_a RedisClient::SentinelConfig
+          expect(raw_client.config.password).to eq('mypassword')
+
+          sentinels = raw_client.config.sentinels
+          expect(sentinels.map(&:username).uniq).to eq([sentinel_username])
+          expect(sentinels.map(&:password).uniq).to eq([sentinel_password])
+        end
+      end
     end
   end
 end

--- a/spec/lib/arbitration/redis_spec.rb
+++ b/spec/lib/arbitration/redis_spec.rb
@@ -96,7 +96,7 @@ describe MailRoom::Arbitration::Redis do
       it 'client has same specified url' do
         subject.deliver?(123)
 
-        expect(raw_client.options[:url]).to eq redis_url
+        expect(raw_client.config.server_url).to eq redis_url
       end
 
       it 'client is a instance of Redis class' do
@@ -135,13 +135,14 @@ describe MailRoom::Arbitration::Redis do
         )
       }
 
-      before { ::Redis::Client::Connector::Sentinel.any_instance.stubs(:resolve).returns(sentinels) }
+      before { ::RedisClient::SentinelConfig.any_instance.stubs(:resolve_master).returns(RedisClient::Config.new(**sentinels.first)) }
 
       it 'client has same specified sentinel params' do
-        expect(raw_client.instance_variable_get(:@connector)).to be_a Redis::Client::Connector::Sentinel
-        expect(raw_client.options[:host]).to eq('sentinel-master')
-        expect(raw_client.options[:password]).to eq('mypassword')
-        expect(raw_client.options[:sentinels]).to eq(sentinels)
+        expect(raw_client.config).to be_a RedisClient::SentinelConfig
+        expect(raw_client.config.name).to eq('sentinel-master')
+        expect(raw_client.config.host).to eq('10.0.0.1')
+        expect(raw_client.config.password).to eq('mypassword')
+        expect(raw_client.config.sentinels.map(&:server_url)).to eq(["redis://10.0.0.1:26379"])
       end
     end
   end


### PR DESCRIPTION
As documented in https://github.com/redis-rb/redis-client?tab=readme-ov-file#sentinel-support, redis-client allows `sentinel_username` and `sentinel_password` to be specified to avoid duplication of the `username` and `password`
fields inside the `sentinels` array.