### PR TITLE
Fix Postback handler not working properly with proxy settings

### DIFF
--- a/lib/mail_room/delivery/postback.rb
+++ b/lib/mail_room/delivery/postback.rb
@@ -75,9 +75,7 @@ module MailRoom
           config_basic_auth(connection)
         end
 
-        result = connection.post do |request|
-          request.url @delivery_options.url
-          request.body = message
+        result = connection.post(@delivery_options.url, message) do |request|
           config_request_content_type(request)
           config_request_jwt_auth(request)
         end


### PR DESCRIPTION
Previously if `no_proxy` were set, the Postback adapter would ignore it. Suppose you defined `http_proxy=http://127.0.0.1:8080` and set `no_proxy` to `.example.com`.

Previously the Postback handler did:

```ruby
connection = Faraday.new
connection.post do |request|
  result.url('http://example.com')
end
```

In this form, the proxy would always be used. However, if you do this, it works fine:

```ruby
connection = Faraday.new
connection.post('http://example.com')
```

This happened because `Faraday::Connection#run_request` calls `proxy_from_env` immediately
(https://github.com/lostisland/faraday/blob/v2.12.2/lib/faraday/connection.rb#L445), but it can't set this if the URL is altered underneath it.

Fix this by passing in the URL and body directly to the `#post` method.